### PR TITLE
remove codeIgniter cache construct limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Use any [CodeIgniter Cache](https://www.codeigniter.com/userguide3/libraries/cac
 ```php
 use Mpociot\BotMan\Cache\CodeIgniterCache;
 
-$botman = BotManFactory::create($config, new CodeIgniterCache($codeIgniterCache));
+$this->load->driver('cache');
+$botman = BotManFactory::create($config, new CodeIgniterCache($this->cache->file));
 ```
 
 ## Connect with your messaging service

--- a/src/Mpociot/BotMan/Cache/CodeIgniterCache.php
+++ b/src/Mpociot/BotMan/Cache/CodeIgniterCache.php
@@ -13,7 +13,7 @@ class CodeIgniterCache implements CacheInterface
     private $cache;
 
     /**
-     * @param CI_Cache $driver
+     * @param array $driver
      */
     public function __construct($driver)
     {

--- a/src/Mpociot/BotMan/Cache/CodeIgniterCache.php
+++ b/src/Mpociot/BotMan/Cache/CodeIgniterCache.php
@@ -2,7 +2,6 @@
 
 namespace Mpociot\BotMan\Cache;
 
-use CI_Cache;
 use Mpociot\BotMan\Interfaces\CacheInterface;
 
 class CodeIgniterCache implements CacheInterface

--- a/src/Mpociot/BotMan/Cache/CodeIgniterCache.php
+++ b/src/Mpociot/BotMan/Cache/CodeIgniterCache.php
@@ -15,7 +15,7 @@ class CodeIgniterCache implements CacheInterface
     /**
      * @param CI_Cache $driver
      */
-    public function __construct(CI_Cache $driver)
+    public function __construct($driver)
     {
         $this->cache = $driver;
     }


### PR DESCRIPTION
Hi mpociot,
codeIgniter cache class different...

For example use file driver below:
$this->load->driver('cache');
new CodeIgniterCache($this->cache->file); // Class is CI_Cache_file

For example use redis driver below:
$this->load->driver('cache');
new CodeIgniterCache($this->cache->redis); // Class is CI_Cache_redis

Can i remove construct limit for CodeIgniterCache?

I could use your assistance on this.. Thx
