### PR TITLE
Add ability to use invokable controllers

### DIFF
--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -12,6 +12,7 @@ use Mpociot\BotMan\Interfaces\CacheInterface;
 use Mpociot\BotMan\Interfaces\DriverInterface;
 use Mpociot\BotMan\Interfaces\StorageInterface;
 use Mpociot\BotMan\Interfaces\MiddlewareInterface;
+use UnexpectedValueException;
 
 /**
  * Class BotMan.
@@ -198,6 +199,10 @@ class BotMan
             $callback = $messageData['callback'];
 
             if (! $callback instanceof Closure) {
+                if (strpos($callback, '@') === false) {
+                    $callback = $this->makeInvokableAction($callback);
+                }
+
                 list($class, $method) = explode('@', $callback);
                 $callback = [new $class, $method];
             }
@@ -474,6 +479,25 @@ class BotMan
         }
 
         return true;
+    }
+
+    /**
+     * Make an action for an invokable controller.
+     *
+     * @param string $action
+     * @return string
+     *
+     * @throws \UnexpectedValueException
+     */
+    protected function makeInvokableAction($action)
+    {
+        if (! method_exists($action, '__invoke')) {
+            throw new UnexpectedValueException(sprintf(
+                'Invalid route action: [%s]', $action
+            ));
+        }
+
+        return $action.'@__invoke';
     }
 
     /**

--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -3,6 +3,7 @@
 namespace Mpociot\BotMan;
 
 use Closure;
+use UnexpectedValueException;
 use Illuminate\Support\Collection;
 use Opis\Closure\SerializableClosure;
 use Mpociot\BotMan\Drivers\SlackRTMDriver;
@@ -12,7 +13,6 @@ use Mpociot\BotMan\Interfaces\CacheInterface;
 use Mpociot\BotMan\Interfaces\DriverInterface;
 use Mpociot\BotMan\Interfaces\StorageInterface;
 use Mpociot\BotMan\Interfaces\MiddlewareInterface;
-use UnexpectedValueException;
 
 /**
  * Class BotMan.


### PR DESCRIPTION
Make an ability to use invokable controllers.

```php
$botman->hears('hello', 'App\Http\Controllers\HelloController');
```

If no `@` symbol is found in action `__invoke` method will be used.

```php
class HelloController extends Controller
{
    public function __invoke(BotMan $bot)
    {
        $bot->reply('No, you!');
    }
}
```

Implemented the same way as in Laravel.