### PR TITLE
Remove cons, since it's fixed by Slack

### DIFF
--- a/readme-slack.md
+++ b/readme-slack.md
@@ -31,7 +31,6 @@
 
 **Cons:** 
   * Pretty cumbersome to set up *Note:* Let the folks from [SlackHQ](https://twitter.com/slackhq) know this. If we make enough noise, they'll hopefully simplify the bot token creation process!
-  * Your bot user will appear offline
 
 ---
 


### PR DESCRIPTION
It's now possible to select that the bot should always show as online.