### PR TITLE
Check isBot when listening

### DIFF
--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -208,7 +208,7 @@ class BotMan
             }
 
             foreach ($this->getMessages() as $message) {
-                if (!$this->isBot() && 
+                if (! $this->isBot() && 
                     $this->isMessageMatching($message, $pattern, $matches) &&
                     $this->isDriverValid($this->driver->getName(), $messageData['driver']) &&
                     $this->isChannelValid($message->getChannel(), $messageData['in']) &&

--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -208,7 +208,8 @@ class BotMan
             }
 
             foreach ($this->getMessages() as $message) {
-                if ($this->isMessageMatching($message, $pattern, $matches) &&
+                if (!$this->isBot() && 
+                    $this->isMessageMatching($message, $pattern, $matches) &&
                     $this->isDriverValid($this->driver->getName(), $messageData['driver']) &&
                     $this->isChannelValid($message->getChannel(), $messageData['in']) &&
                     $this->loadedConversation === false

--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -208,7 +208,7 @@ class BotMan
             }
 
             foreach ($this->getMessages() as $message) {
-                if (! $this->isBot() && 
+                if (! $this->isBot() &&
                     $this->isMessageMatching($message, $pattern, $matches) &&
                     $this->isDriverValid($this->driver->getName(), $messageData['driver']) &&
                     $this->isChannelValid($message->getChannel(), $messageData['in']) &&


### PR DESCRIPTION
When using the SlackRTM driver, if you use the following:

    $botman->hears('Hello', function ($bot) {
        $bot->reply('Hello!');
    });

Then it causes an infinite loop.

The fix _seems_ pretty simply in that we check that the user isn't a bot when looping through the messages on the listen method.