### PR TITLE
Make the Facebook app secret required

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $config = [
     'slack_token' => 'YOUR-SLACK-TOKEN-HERE',
     'telegram_token' => 'YOUR-TELEGRAM-TOKEN-HERE',
     'facebook_token' => 'YOUR-FACEBOOK-TOKEN-HERE',
-    'facebook_app_secret' => 'YOUR-FACEBOOK-APP-SECRET-HERE' // Optional - this is used to verify incoming API calls,
+    'facebook_app_secret' => 'YOUR-FACEBOOK-APP-SECRET-HERE' // This is used to verify incoming API calls,
     'wechat_app_id' => 'YOUR-WECHAT-APP-ID',
     'wechat_app_key' => 'YOUR-WECHAT-APP-KEY',
 ];

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -26,7 +26,7 @@ For Laravel, the page access token needs to be in your `config/services.php` fil
 ```php
     'botman' => [
     	'facebook_token' => 'YOUR-FACEBOOK-PAGE-TOKEN-HERE',
-    	'facebook_app_secret' => 'YOUR-FACEBOOK-APP-SECRET-HERE', // Optional - this is used to verify incoming API calls
+    	'facebook_app_secret' => 'YOUR-FACEBOOK-APP-SECRET-HERE', // This is used to verify incoming API calls
     ],
 ```
 

--- a/src/Mpociot/BotMan/Drivers/FacebookDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FacebookDriver.php
@@ -54,7 +54,7 @@ class FacebookDriver extends Driver
      */
     public function matchesRequest()
     {
-        $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
+        $validSignature = $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
             return isset($msg['message']) && isset($msg['message']['text']);
         });

--- a/tests/Drivers/FacebookDriverTest.php
+++ b/tests/Drivers/FacebookDriverTest.php
@@ -37,7 +37,8 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($driver->matchesRequest());
 
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi"}}]}]}';
-        $driver = $this->getDriver($request);
+        $signatureComparison = 'sha1='.hash_hmac('sha1', $request, '');
+        $driver = $this->getDriver($request, ['facebook_token' => 'Foo'], $signatureComparison);
         $this->assertTrue($driver->matchesRequest());
 
         $config = ['facebook_token' => 'Foo', 'facebook_app_secret' => 'Bar'];


### PR DESCRIPTION
Hey @mpociot ,

I thought it could be a good idea to make the Facebook app secret a "required" field. Since this is an important security step, I would not recommend making it optional. People will forget about it. If you also think this way, here is the PR. If not, don't mind.

Greets

PS: I could also provide a PR for the Laravel starter if want.