### PR TITLE
Correctly handle Skype group chats

### DIFF
--- a/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
+++ b/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
@@ -74,7 +74,11 @@ class BotFrameworkDriver extends Driver
      */
     public function getMessages()
     {
-        return [new Message($this->event->get('text'), $this->event->get('from')['id'], $this->event->get('conversation')['id'], $this->payload)];
+        // replace bot's name for group chats and special characters that might be sent from Web Skype
+        $pattern = '/<at id=(.*?)at>[^(\x20-\x7F)\x0A]*\s*/';
+        $message = preg_replace($pattern, '', $this->event->get('text'));
+
+        return [new Message($message, $this->event->get('from')['id'], $this->event->get('conversation')['id'], $this->payload)];
     }
 
     /**

--- a/tests/Drivers/BotFrameworkDriverTest.php
+++ b/tests/Drivers/BotFrameworkDriverTest.php
@@ -23,50 +23,9 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
         return new BotFrameworkDriver($request, [], $htmlInterface);
     }
 
-    /** @test */
-    public function it_returns_the_driver_name()
+    private function getResponseData()
     {
-        $driver = $this->getDriver([]);
-        $this->assertSame('BotFramework', $driver->getName());
-    }
-
-    /** @test */
-    public function it_matches_the_request()
-    {
-        $driver = $this->getDriver([
-            'event' => [
-                'text' => 'bar',
-            ],
-        ]);
-        $this->assertFalse($driver->matchesRequest());
-
-        $driver = $this->getDriver([
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                    'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                    'name' => 'Julia',
-            ],
-            'conversation' => [
-                    'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                    'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                    'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ]);
-        $this->assertTrue($driver->matchesRequest());
-    }
-
-    /** @test */
-    public function it_returns_the_message_object()
-    {
-        $driver = $this->getDriver([
+        return [
             'type' => 'message',
             'id' => '4IIOjFkzcYy1HbYO',
             'timestamp' => '2016-11-29T21:58:31.879Z',
@@ -85,7 +44,34 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
             ],
             'text' => 'hey there',
             'entities' => [],
+        ];
+    }
+
+    /** @test */
+    public function it_returns_the_driver_name()
+    {
+        $driver = $this->getDriver([]);
+        $this->assertSame('BotFramework', $driver->getName());
+    }
+
+    /** @test */
+    public function it_matches_the_request()
+    {
+        $driver = $this->getDriver([
+            'event' => [
+                'text' => 'bar',
+            ],
         ]);
+        $this->assertFalse($driver->matchesRequest());
+
+        $driver = $this->getDriver($this->getResponseData());
+        $this->assertTrue($driver->matchesRequest());
+    }
+
+    /** @test */
+    public function it_returns_the_message_object()
+    {
+        $driver = $this->getDriver($this->getResponseData());
         $this->assertTrue(is_array($driver->getMessages()));
     }
 
@@ -116,80 +102,34 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_replaces_bot_name_in_group_chat()
+    {
+        $responseData = $this->getResponseData();
+        $responseData['text'] = '<at id="28:3176e6ca-8dad-4c6d-97f1-e2a86548acc8">@Bot</at>    Hi Maks';
+
+        $driver = $this->getDriver($responseData);
+
+        $this->assertSame('Hi Maks', $driver->getMessages()[0]->getMessage());
+    }
+
+    /** @test */
     public function it_detects_bots()
     {
-        $driver = $this->getDriver([
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ]);
+        $driver = $this->getDriver($this->getResponseData());
         $this->assertFalse($driver->isBot());
     }
 
     /** @test */
     public function it_returns_the_user_id()
     {
-        $driver = $this->getDriver([
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ]);
+        $driver = $this->getDriver($this->getResponseData());
         $this->assertSame('29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1', $driver->getMessages()[0]->getUser());
     }
 
     /** @test */
     public function it_returns_the_channel_id()
     {
-        $driver = $this->getDriver([
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ]);
+        $driver = $this->getDriver($this->getResponseData());
         $this->assertSame('29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1', $driver->getMessages()[0]->getChannel());
     }
 
@@ -276,26 +216,7 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_can_reply_string_messages()
     {
-        $responseData = [
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ];
+        $responseData = $this->getResponseData();
 
         $html = m::mock(Curl::class);
         $html->shouldReceive('post')
@@ -335,26 +256,7 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_can_reply_with_additional_parameters()
     {
-        $responseData = [
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ];
+        $responseData = $this->getResponseData();
 
         $html = m::mock(Curl::class);
         $html->shouldReceive('post')
@@ -397,26 +299,7 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_can_reply_message_objects()
     {
-        $responseData = [
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ];
+        $responseData = $this->getResponseData();
 
         $html = m::mock(Curl::class);
         $html->shouldReceive('post')
@@ -456,26 +339,7 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_can_reply_message_objects_with_image()
     {
-        $responseData = [
-            'type' => 'message',
-            'id' => '4IIOjFkzcYy1HbYO',
-            'timestamp' => '2016-11-29T21:58:31.879Z',
-            'serviceUrl' => 'https://skype.botframework.com',
-            'channelId' => 'skype',
-            'from' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-                'name' => 'Julia',
-            ],
-            'conversation' => [
-                'id' => '29:1zPNq1EP2_H-mik_1MQgKYp0nZu9tUljr2VEdTlGhEo7VlZ1YVDVSUZ0g70sk1',
-            ],
-            'recipient' => [
-                'id' => '28:a91af6d0-0e59-4adb-abcf-b6a1f728e3f3',
-                'name' => 'BotMan',
-            ],
-            'text' => 'hey there',
-            'entities' => [],
-        ];
+        $responseData = $this->getResponseData();
 
         $html = m::mock(Curl::class);
         $html->shouldReceive('post')


### PR DESCRIPTION
Correctly handle Skype group chats when sending the messages to the Bot. Fixes #104 

Please note that Web Skype adds some strange character when you send a message to the bot, so the regular expression removes it. 

You can find the detailed example here: https://3v4l.org/GXvON