### PR TITLE
Use a more secure hash comparison  method

### DIFF
--- a/src/Mpociot/BotMan/Drivers/FacebookDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FacebookDriver.php
@@ -67,7 +67,7 @@ class FacebookDriver extends Driver
      */
     protected function validateSignature()
     {
-        return $this->signature == 'sha1='.hash_hmac('sha1', $this->content, $this->config->get('facebook_app_secret'));
+        return hash_equals($this->signature, 'sha1='.hash_hmac('sha1', $this->content, $this->config->get('facebook_app_secret')));
     }
 
     /**


### PR DESCRIPTION
This method compares hashed with the same time, which makes it more secure.