### PR TITLE
Feature/add repeat params

### DIFF
--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -49,7 +49,7 @@ abstract class Conversation
     {
         $conversation = $this->bot->getStoredConversation();
 
-        if(!$question instanceof Question && !$question) {
+        if (! $question instanceof Question && ! $question) {
             $question = unserialize($conversation['question']);
         }
 

--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -43,7 +43,7 @@ abstract class Conversation
 
     /**
      * Repeat the previously asked question.
-     * @param string $question
+     * @param string|Question $question
      */
     public function repeat($question = '')
     {

--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -43,12 +43,17 @@ abstract class Conversation
 
     /**
      * Repeat the previously asked question.
-     * @return $this
+     * @param string $question
      */
-    public function repeat()
+    public function repeat($question = '')
     {
         $conversation = $this->bot->getStoredConversation();
-        $this->ask(unserialize($conversation['question']), unserialize($conversation['next'])->getClosure(), unserialize($conversation['additionalParameters']));
+
+        if(!$question instanceof Question && !$question) {
+            $question = unserialize($conversation['question']);
+        }
+
+        $this->ask($question, unserialize($conversation['next'])->getClosure(), unserialize($conversation['additionalParameters']));
     }
 
     /**


### PR DESCRIPTION
It would be nice if it is possible to add a different question to the `repeat` method. Often you want to repeat a question but you need to change it. Now it is possible to use a string or question object as optional param.