### PR TITLE
Bugfix/repeat with array of callbacks

### DIFF
--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -48,13 +48,22 @@ abstract class Conversation
     public function repeat($question = '')
     {
         $conversation = $this->bot->getStoredConversation();
+
         if (! $question instanceof Question && ! $question) {
             $question = unserialize($conversation['question']);
         }
+
         $next = $conversation['next'];
         $additionalParameters = unserialize($conversation['additionalParameters']);
+
         if (is_string($next)) {
             $next = unserialize($next)->getClosure();
+        } elseif (is_array($next)) {
+            $next = collect($next)->map(function ($callback) {
+                $callback['callback'] = unserialize($callback['callback'])->getClosure();
+
+                return $callback;
+            })->toArray();
         }
         $this->ask($question, $next, $additionalParameters);
     }


### PR DESCRIPTION
The `repeat` method did nor work for array of callbacks. Now it does.