### PR TITLE
support range quantifiers in regexes

### DIFF
--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -21,6 +21,12 @@ class BotMan
 {
     use VerifiesServices, ProvidesStorage;
 
+    /**
+     * regular expression to capture named parameters but not quantifiers
+     * captures {name}, but not {1}, {1,}, or {1,2}
+     */
+    const PARAM_NAME_REGEX = '/\{((?:(?!\d+,?\d+?)\w)+?)\}/';
+
     /** @var \Symfony\Component\HttpFoundation\ParameterBag */
     public $payload;
 
@@ -176,7 +182,7 @@ class BotMan
      */
     protected function compileParameterNames($value)
     {
-        preg_match_all('/\{(.*?)\}/', $value, $matches);
+        preg_match_all(self::PARAM_NAME_REGEX, $value, $matches);
 
         return array_map(function ($m) {
             return trim($m, '?');
@@ -282,7 +288,7 @@ class BotMan
         $answerText = $this->getConversationAnswer()->getValue();
 
         $pattern = str_replace('/', '\/', $pattern);
-        $text = '/^'.preg_replace('/\{(\w+?)\}/', '(.*)', $pattern).'$/i';
+        $text = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(.*)', $pattern).'$/i';
         $regexMatched = (bool) preg_match($text, $messageText, $matches) || (bool) preg_match($text, $answerText, $matches);
 
         // Try middleware first

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -436,6 +436,26 @@ class BotManTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_allows_regular_expressions_with_range_quantifier()
+    {
+        $called = false;
+
+        $botman = $this->getBot([
+            'event' => [
+                'user' => 'U0X12345',
+                'text' => 'look at order #123456789',
+            ],
+        ]);
+
+        $botman->hears('.*?#(\d{8,9})\b.*', function ($bot, $orderId) use (&$called) {
+            $called = true;
+            $this->assertSame('123456789', $orderId);
+        });
+        $botman->listen();
+        $this->assertTrue($called);
+    }
+
+    /** @test */
     public function it_returns_regular_expression_matches()
     {
         $called = false;


### PR DESCRIPTION
Named parameters {name})and regex quantifiers \d{2,4} conflict.

This PR provides:
    /**
     * regular expression to capture named parameters but not quantifiers
     * captures {name}, but not {1}, {1,}, or {1,2}
     */
    const PARAM_NAME_REGEX = '/\{((?:(?!\d+,?\d+?)\w)+?)\}/';
