### PR TITLE
Apply PSR-6 cache driver

### DIFF
--- a/src/Mpociot/BotMan/Cache/Psr6Cache.php
+++ b/src/Mpociot/BotMan/Cache/Psr6Cache.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Mpociot\BotMan\Cache;
+
+use Mpociot\BotMan\Interfaces\CacheInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class Psr6Cache implements CacheInterface
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    protected $adapter;
+
+    /**
+     * @param CacheItemPoolInterface $adapter
+     */
+    public function __construct(CacheItemPoolInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * @param string $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->adapter->hasItem($key);
+    }
+
+    /**
+     * @param string $key
+     * @param null $default
+     * @return mixed|null
+     */
+    public function get($key, $default = null)
+    {
+        $item = $this->adapter->getItem($key);
+        if ($item->isHit()) {
+            return $item->get();
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param string $key
+     * @param null $default
+     * @return null
+     */
+    public function pull($key, $default = null)
+    {
+        $item = $this->adapter->getItem($key);
+        if ($item->isHit()) {
+            $this->adapter->deleteItem($key);
+
+            return $item->get();
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @param \DateTime|int $minutes
+     */
+    public function put($key, $value, $minutes)
+    {
+        $item = $this->adapter->getItem($key);
+        $item->set($value);
+
+        if ($minutes instanceof \DateTimeInterface) {
+            $item->expiresAt($minutes);
+        } else {
+            $item->expiresAfter(new \DateInterval(sprintf('PT%dM', $minutes)));
+        }
+
+        $this->adapter->save($item);
+    }
+}

--- a/src/Mpociot/BotMan/Cache/Psr6Cache.php
+++ b/src/Mpociot/BotMan/Cache/Psr6Cache.php
@@ -2,8 +2,8 @@
 
 namespace Mpociot\BotMan\Cache;
 
-use Mpociot\BotMan\Interfaces\CacheInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Mpociot\BotMan\Interfaces\CacheInterface;
 
 class Psr6Cache implements CacheInterface
 {

--- a/src/Mpociot/BotMan/Cache/SymfonyCache.php
+++ b/src/Mpociot/BotMan/Cache/SymfonyCache.php
@@ -2,81 +2,15 @@
 
 namespace Mpociot\BotMan\Cache;
 
-use Mpociot\BotMan\Interfaces\CacheInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 
-class SymfonyCache implements CacheInterface
+class SymfonyCache extends Psr6Cache
 {
-    /**
-     * @var AdapterInterface
-     */
-    private $adapter;
-
     /**
      * @param AdapterInterface $adapter
      */
     public function __construct(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
-    }
-
-    /**
-     * @param string $key
-     * @return bool
-     */
-    public function has($key)
-    {
-        return $this->adapter->hasItem($key);
-    }
-
-    /**
-     * @param string $key
-     * @param null $default
-     * @return mixed|null
-     */
-    public function get($key, $default = null)
-    {
-        $item = $this->adapter->getItem($key);
-        if ($item->isHit()) {
-            return $item->get();
-        }
-
-        return $default;
-    }
-
-    /**
-     * @param string $key
-     * @param null $default
-     * @return null
-     */
-    public function pull($key, $default = null)
-    {
-        $item = $this->adapter->getItem($key);
-        if ($item->isHit()) {
-            $this->adapter->deleteItem($key);
-
-            return $item->get();
-        }
-
-        return $default;
-    }
-
-    /**
-     * @param string $key
-     * @param mixed $value
-     * @param \DateTime|int $minutes
-     */
-    public function put($key, $value, $minutes)
-    {
-        $item = $this->adapter->getItem($key);
-        $item->set($value);
-
-        if ($minutes instanceof \DateTimeInterface) {
-            $item->expiresAt($minutes);
-        } else {
-            $item->expiresAfter(new \DateInterval(sprintf('PT%dM', $minutes)));
-        }
-
-        $this->adapter->save($item);
     }
 }

--- a/tests/Cache/Psr6CacheTest.php
+++ b/tests/Cache/Psr6CacheTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Mpociot\BotMan\Tests;
+
+use Mockery as m;
+use PHPUnit_Framework_TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Mpociot\BotMan\Cache\Psr6Cache;
+
+class Psr6CacheTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /** @test */
+    public function has()
+    {
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('hasItem')->once()->andReturn(true);
+
+        $cache = new Psr6Cache($driver);
+        $this->assertTrue($cache->has('foo'));
+    }
+
+    /** @test */
+    public function has_not()
+    {
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('hasItem')->once()->andReturn(false);
+
+        $cache = new Psr6Cache($driver);
+        $this->assertFalse($cache->has('foo'));
+    }
+
+    /** @test */
+    public function get_existing_key()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('isHit')->once()->andReturn(true);
+        $item->shouldReceive('get')->once()->andReturn('bar');
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->andReturn($item);
+
+        $cache = new Psr6Cache($driver);
+        $this->assertEquals('bar', $cache->get('foo', null));
+    }
+
+    /** @test */
+    public function get_non_existing_key()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('isHit')->once()->andReturn(false);
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->andReturn($item);
+
+        $cache = new Psr6Cache($driver);
+        $this->assertNull($cache->get('foo', null));
+    }
+
+    /** @test */
+    public function pull_existing_key()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('isHit')->once()->andReturn(true);
+        $item->shouldReceive('get')->once()->andReturn('bar');
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->andReturn($item);
+        $driver->shouldReceive('deleteItem')->once();
+
+        $cache = new Psr6Cache($driver);
+        $this->assertEquals('bar', $cache->pull('foo', null));
+    }
+
+    /** @test */
+    public function pull_non_existing_key()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('isHit')->once()->andReturn(false);
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->andReturn($item);
+
+        $cache = new Psr6Cache($driver);
+        $this->assertNull($cache->pull('foo', null));
+    }
+
+    /** @test */
+    public function pull_non_existing_key_with_default_value()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('isHit')->once()->andReturn(false);
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->andReturn($item);
+
+        $cache = new Psr6Cache($driver);
+        $this->assertEquals('bar', $cache->pull('foo', 'bar'));
+    }
+
+    /** @test */
+    public function put()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('set')->once()->withArgs(['bar']);
+        $item->shouldReceive('expiresAfter')->once();
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->withArgs(['foo'])->andReturn($item);
+        $driver->shouldReceive('save')->once();
+
+        $cache = new Psr6Cache($driver);
+        $cache->put('foo', 'bar', 5);
+    }
+
+    /** @test */
+    public function put_with_datetime()
+    {
+        $item = m::mock(CacheItemInterface::class);
+        $item->shouldReceive('set')->once()->withArgs(['bar']);
+        $item->shouldReceive('expiresAt')->once();
+
+        $driver = m::mock(CacheItemPoolInterface::class);
+        $driver->shouldReceive('getItem')->once()->withArgs(['foo'])->andReturn($item);
+        $driver->shouldReceive('save')->once();
+
+        $cache = new Psr6Cache($driver);
+        $cache->put('foo', 'bar', new \DateTime('+5 minutes'));
+    }
+}

--- a/tests/Cache/Psr6CacheTest.php
+++ b/tests/Cache/Psr6CacheTest.php
@@ -5,8 +5,8 @@ namespace Mpociot\BotMan\Tests;
 use Mockery as m;
 use PHPUnit_Framework_TestCase;
 use Psr\Cache\CacheItemInterface;
-use Psr\Cache\CacheItemPoolInterface;
 use Mpociot\BotMan\Cache\Psr6Cache;
+use Psr\Cache\CacheItemPoolInterface;
 
 class Psr6CacheTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
The symfony cache driver is build on [PSR-6](http://www.php-fig.org/psr/psr-6/), but only works with `Symfony\Component\Cache\Adapter\AdapterInterface` implementations.

This PR applies a new PSR-6 cache drive, that works with `Psr\Cache\CacheItemPoolInterface` implementations. And the Symfony cache driver extends now the PSR-6 cache driver.