### PR TITLE
Fix send GIF images in Telegram driver

### DIFF
--- a/src/Mpociot/BotMan/Drivers/TelegramDriver.php
+++ b/src/Mpociot/BotMan/Drivers/TelegramDriver.php
@@ -189,8 +189,13 @@ class TelegramDriver extends Driver
             ], true);
         } elseif ($message instanceof IncomingMessage) {
             if (! is_null($message->getImage())) {
-                $endpoint = 'sendPhoto';
-                $parameters['photo'] = $message->getImage();
+                if (strtolower(pathinfo($message->getImage(), PATHINFO_EXTENSION)) === 'gif') {
+                    $endpoint = 'sendDocument';
+                    $parameters['document'] = $message->getImage();
+                } else {
+                    $endpoint = 'sendPhoto';
+                    $parameters['photo'] = $message->getImage();
+                }
                 $parameters['caption'] = $message->getMessage();
             } elseif (! is_null($message->getVideo())) {
                 $endpoint = 'sendVideo';

--- a/tests/Drivers/TelegramDriverTest.php
+++ b/tests/Drivers/TelegramDriverTest.php
@@ -526,6 +526,44 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_reply_message_objects_with_gif_image()
+    {
+        $responseData = [
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => '12345',
+                ],
+                'date' => '1480369277',
+                'text' => 'Telegram Text',
+            ],
+        ];
+
+        $html = m::mock(Curl::class);
+        $html->shouldReceive('post')
+            ->once()
+            ->with('https://api.telegram.org/botTELEGRAM-BOT-TOKEN/sendDocument', [], [
+                'chat_id' => '12345',
+                'document' => 'http://image.url/foo.gif',
+                'caption' => 'Test',
+            ]);
+
+        $request = m::mock(\Illuminate\Http\Request::class.'[getContent]');
+        $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
+
+        $driver = new TelegramDriver($request, [
+            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
+        ], $html);
+
+        $message = $driver->getMessages()[0];
+        $driver->reply(\Mpociot\BotMan\Messages\Message::create('Test', 'http://image.url/foo.gif'), $message);
+    }
+
+    /** @test */
     public function it_can_reply_message_objects_with_video()
     {
         $responseData = [


### PR DESCRIPTION
For correct send GIF images need to use sendDocument endpoint in
Telegram driver