### PR TITLE
[Api.ai] [Fix] The field 'sessionId' must not exceed 36 symbols.

### DIFF
--- a/src/Mpociot/BotMan/Middleware/ApiAi.php
+++ b/src/Mpociot/BotMan/Middleware/ApiAi.php
@@ -65,7 +65,7 @@ class ApiAi implements MiddlewareInterface
     {
         $response = $this->http->post($this->apiUrl, [], [
             'query' => [$message->getMessage()],
-            'sessionId' => sha1($message->getChannel()),
+            'sessionId' => substr(sha1($message->getChannel()), 0, 36),
             'lang' => 'en',
         ], [
             'Authorization: Bearer '.$this->token,

--- a/src/Mpociot/BotMan/Middleware/ApiAi.php
+++ b/src/Mpociot/BotMan/Middleware/ApiAi.php
@@ -65,7 +65,7 @@ class ApiAi implements MiddlewareInterface
     {
         $response = $this->http->post($this->apiUrl, [], [
             'query' => [$message->getMessage()],
-            'sessionId' => substr(sha1($message->getChannel()), 0, 36),
+            'sessionId' => md5($message->getChannel()),
             'lang' => 'en',
         ], [
             'Authorization: Bearer '.$this->token,

--- a/tests/Middleware/ApiAiTest.php
+++ b/tests/Middleware/ApiAiTest.php
@@ -38,7 +38,7 @@ class ApiAiTest extends PHPUnit_Framework_TestCase
             ->once()
             ->with('https://api.api.ai/v1/query', [], [
                 'query' => [$messageText],
-                'sessionId' => sha1($messageChannel),
+                'sessionId' => substr(sha1($messageChannel), 0, 36),
                 'lang' => 'en',
             ], [
                 'Authorization: Bearer token',

--- a/tests/Middleware/ApiAiTest.php
+++ b/tests/Middleware/ApiAiTest.php
@@ -38,7 +38,7 @@ class ApiAiTest extends PHPUnit_Framework_TestCase
             ->once()
             ->with('https://api.api.ai/v1/query', [], [
                 'query' => [$messageText],
-                'sessionId' => substr(sha1($messageChannel), 0, 36),
+                'sessionId' => md5($messageChannel),
                 'lang' => 'en',
             ], [
                 'Authorization: Bearer token',


### PR DESCRIPTION
Maximum length of sessionId parameter is 36

doc: https://docs.api.ai/docs/query
