### PR TITLE
publish access to \Slack\RealTimeClient

### DIFF
--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -178,10 +178,28 @@ class SlackRTMDriver implements DriverInterface
     /**
      * Retrieve User information.
      * @param Message $matchingMessage
-     * @return User
+     * @return \Slack\User
      */
     public function getUser(Message $matchingMessage)
     {
-        return new User($matchingMessage->getUser());
+        return $this->client->getUserById($matchingMessage->getUser());
+    }
+
+    /**
+     * Retrieve Channel information.
+     * @param Message $matchingMessage
+     * @return \Slack\Channel
+     */
+    public function getChannel(Message $matchingMessage)
+    {
+        return $this->client->getChannelById($matchingMessage->getChannel());
+    }
+
+    /**
+     * @return RealTimeClient
+     */
+    public function getClient()
+    {
+        return $this->client;
     }
 }


### PR DESCRIPTION
in `$botman->hears()` we have access to `$bot->getUser()` but it has no user details. `SlackRTMDriver` has `protected $client` `RealTimeClient` that has information about all users. the point that we have no access to `$client` outside `SlackRTMDriver`. so I add `public function getClient()` to `SlackRTMDriver` to run `$client->getUserById()` in `hears()` and fix `$bot->getUser()` for `SlackRTMDriver` to return filled `\Slack\User`

so we can do this
```php
$botman->hears(
	'ping',
	function (\Mpociot\BotMan\BotMan $bot) {
		/** @var \Slack\RealTimeClient $client */
		$client = $bot->getDriver()->getClient();
		$client->getTeam()->then(function($value) {
			var_dump($value);
		});

		$bot->getUser()->then(
			function ($user) use ($bot) {
				$user_name = $user->getUsername();
				$bot->reply('*pong* :metal: ' . $user_name);
			}
		);
	}
);

```