### PR TITLE
Make converstation cache time editable

### DIFF
--- a/src/Mpociot/BotMan/Traits/HandlesConversations.php
+++ b/src/Mpociot/BotMan/Traits/HandlesConversations.php
@@ -42,7 +42,7 @@ trait HandlesConversations
             'additionalParameters' => serialize($additionalParameters),
             'next' => $this->prepareCallbacks($next),
             'time' => microtime(),
-        ], 30);
+        ], isset($this->config['conv_cache_time']) ? $this->config['conv_cache_time'] : 30);
     }
 
     /**


### PR DESCRIPTION
You can now change the conversation cache time which is 30min by default. In order to change it just add `conv_cache_time` to the botman config.

Maybe there is a nicer way to check if the value is set in the config than my implementation. If you're ok with this PR I would add another one for the documentation.