### PR TITLE
Implement typing indicator for Slack RTM driver

### DIFF
--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -169,10 +169,17 @@ class SlackRTMDriver implements DriverInterface
     /**
      * Send a typing indicator.
      * @param Message $matchingMessage
-     * @return mixed
      */
     public function types(Message $matchingMessage)
     {
+        $channel = null;
+        $this->getChannelGroupOrDM($matchingMessage)->then(function ($_channel) use (&$channel) {
+            $channel = $_channel;
+        });
+
+        if (! is_null($channel)) {
+            $this->client->setAsTyping($channel, false);
+        }
     }
 
     /**
@@ -201,6 +208,16 @@ class SlackRTMDriver implements DriverInterface
     public function getChannel(Message $matchingMessage)
     {
         return $this->client->getChannelById($matchingMessage->getChannel());
+    }
+
+    /**
+     * Retrieve Channel, Group, or DM channel information.
+     * @param Message $matchingMessage
+     * @return \Slack\Channel|\Slack\Group|\Slack\DirectMessageChannel
+     */
+    public function getChannelGroupOrDM(Message $matchingMessage)
+    {
+        return $this->client->getChannelGroupOrDMByID($matchingMessage->getChannel());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/mpociot/botman/issues/264. Requires [version 0.2.10](https://github.com/mpociot/slack-client/releases/tag/0.2.10) of [mpociot/slack-client](https://github.com/mpociot/slack-client).