### PR TITLE
[Facebook] Image ratio

### DIFF
--- a/src/Mpociot/BotMan/Facebook/GenericTemplate.php
+++ b/src/Mpociot/BotMan/Facebook/GenericTemplate.php
@@ -6,8 +6,20 @@ use JsonSerializable;
 
 class GenericTemplate implements JsonSerializable
 {
+    const RATIO_HORIZONTAL = 'horizontal';
+    const RATIO_SQUARE = 'square';
+
+    /** @var array */
+    private static $allowedRatios = [
+        self::RATIO_HORIZONTAL,
+        self::RATIO_SQUARE,
+    ];
+
     /** @var array */
     protected $elements = [];
+
+    /** @var string */
+    protected $imageAspectRatio = self::RATIO_HORIZONTAL;
 
     /**
      * @return static
@@ -44,6 +56,19 @@ class GenericTemplate implements JsonSerializable
     }
 
     /**
+     * @param string $ratio
+     * @return $this
+     */
+    public function addImageAspectRatio($ratio)
+    {
+        if (in_array($ratio, self::$allowedRatios)) {
+            $this->imageAspectRatio = $ratio;
+        }
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -53,6 +78,7 @@ class GenericTemplate implements JsonSerializable
                 'type' => 'template',
                 'payload' => [
                     'template_type' => 'generic',
+                    'image_aspect_ratio' => $this->imageAspectRatio,
                     'elements' => $this->elements,
                 ],
             ],

--- a/tests/Facebook/GenericTemplateTest.php
+++ b/tests/Facebook/GenericTemplateTest.php
@@ -41,4 +41,17 @@ class GenericTemplateTest extends PHPUnit_Framework_TestCase
         $this->assertSame('BotMan Laravel Starter',
             Arr::get($template->toArray(), 'attachment.payload.elements.1.title'));
     }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_square_ratio()
+    {
+        $template = new GenericTemplate;
+        $template->addElement(Element::create('BotMan Documentation'));
+        $template->addImageAspectRatio(GenericTemplate::RATIO_SQUARE);
+
+        $this->assertSame(GenericTemplate::RATIO_SQUARE,
+            Arr::get($template->toArray(), 'attachment.payload.image_aspect_ratio'));
+    }
 }


### PR DESCRIPTION
Added the ability to define image ratio (square or horizontal) in generic templates.

Official docs: 
https://developers.facebook.com/docs/messenger-platform/send-api-reference/generic-template#payload

Example:

```
$bot->reply(GenericTemplate::create()
        ->addImageAspectRatio(GenericTemplate::RATIO_SQUARE)
	->addElements([
		Element::create('BotMan Documentation')
			->subtitle('All about BotMan')
			->image('http://botman.io/img/botman-body.png')
			->addButton(ElementButton::create('visit')->url('http://botman.io'))
			->addButton(ElementButton::create('tell me more')
				->payload('tellmemore')->type('postback')),
		Element::create('BotMan Laravel Starter')
			->subtitle('This is the best way to start with Laravel and BotMan')
			->image('http://botman.io/img/botman-body.png')
			->addButton(ElementButton::create('visit')
				->url('https://github.com/mpociot/botman-laravel-starter')
			)
	])
);
```