### PR TITLE
Only run redis tests when extension loaded

### DIFF
--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -12,6 +12,13 @@ use Mpociot\BotMan\Cache\RedisCache;
  */
 class RedisCacheTest extends PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('Redis extension required');
+        }
+    }
+
     public function tearDown()
     {
         $redis = new Redis();

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -14,7 +14,7 @@ class RedisCacheTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!extension_loaded('redis')) {
+        if (! extension_loaded('redis')) {
             $this->markTestSkipped('Redis extension required');
         }
     }

--- a/tests/Storages/RedisStorageTest.php
+++ b/tests/Storages/RedisStorageTest.php
@@ -12,6 +12,13 @@ use Mpociot\BotMan\Storages\Drivers\RedisStorage;
  */
 class RedisStorageTest extends PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('Redis extension required');
+        }
+    }
+
     public function tearDown()
     {
         $redis = new Redis();

--- a/tests/Storages/RedisStorageTest.php
+++ b/tests/Storages/RedisStorageTest.php
@@ -14,7 +14,7 @@ class RedisStorageTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!extension_loaded('redis')) {
+        if (! extension_loaded('redis')) {
             $this->markTestSkipped('Redis extension required');
         }
     }


### PR DESCRIPTION
If the Redis extension is missing then the Redis-related tests will fail. This PR marks the tests as skipped instead