### PR TITLE
Allow to specify the chat_id for telegram driver in low level sendReq…

### DIFF
--- a/src/Mpociot/BotMan/Drivers/TelegramDriver.php
+++ b/src/Mpociot/BotMan/Drivers/TelegramDriver.php
@@ -213,9 +213,11 @@ class TelegramDriver extends Driver
      */
     public function sendRequest($endpoint, array $parameters, Message $matchingMessage)
     {
-        $parameters = array_merge_recursive([
-            'chat_id' => $matchingMessage->getChannel(),
-        ], $parameters);
+        if(! array_key_exists('chat_id', $parameters)) {
+          $parameters = array_merge_recursive([
+              'chat_id' => $matchingMessage->getChannel(),
+          ], $parameters);
+        }
 
         return $this->http->post('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/'.$endpoint, [], $parameters);
     }


### PR DESCRIPTION
Allow to set a specific `chat_id` to sending messages/stickers/etc to a specific telegram user/channel. Useful to send stickers, messages, in channel managed by a bot.