### PR TITLE
Allow replying to an existing thread for Slack drivers.

### DIFF
--- a/src/Mpociot/BotMan/Drivers/SlackDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackDriver.php
@@ -144,7 +144,7 @@ class SlackDriver extends Driver
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage)
     {
-        $additionalParameters['thread_ts'] = !empty($matchingMessage->getPayload()->get('thread_ts'))
+        $additionalParameters['thread_ts'] = ! empty($matchingMessage->getPayload()->get('thread_ts'))
             ? $matchingMessage->getPayload()->get('thread_ts')
             : $matchingMessage->getPayload()->get('ts');
 

--- a/src/Mpociot/BotMan/Drivers/SlackDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackDriver.php
@@ -144,7 +144,9 @@ class SlackDriver extends Driver
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage)
     {
-        $additionalParameters['thread_ts'] = $matchingMessage->getPayload()->get('ts');
+        $additionalParameters['thread_ts'] = !empty($matchingMessage->getPayload()->get('thread_ts'))
+            ? $matchingMessage->getPayload()->get('thread_ts')
+            : $matchingMessage->getPayload()->get('ts');
 
         return $this->reply($message, $matchingMessage, $additionalParameters);
     }

--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -171,7 +171,7 @@ class SlackRTMDriver implements DriverInterface
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage)
     {
-        $additionalParameters['thread_ts'] = !empty($matchingMessage->getPayload()->get('thread_ts'))
+        $additionalParameters['thread_ts'] = ! empty($matchingMessage->getPayload()->get('thread_ts'))
             ? $matchingMessage->getPayload()->get('thread_ts')
             : $matchingMessage->getPayload()->get('ts');
 

--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -171,7 +171,9 @@ class SlackRTMDriver implements DriverInterface
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage)
     {
-        $additionalParameters['thread_ts'] = $matchingMessage->getPayload()->get('ts');
+        $additionalParameters['thread_ts'] = !empty($matchingMessage->getPayload()->get('thread_ts'))
+            ? $matchingMessage->getPayload()->get('thread_ts')
+            : $matchingMessage->getPayload()->get('ts');
 
         return $this->reply($message, $matchingMessage, $additionalParameters);
     }


### PR DESCRIPTION
Allow replyInThread for Slack drivers to account for replying to an existing thread, not just starting a new thread.

Fix for #327 