### PR TITLE
Check for empty values instead of null

### DIFF
--- a/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
+++ b/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
@@ -186,7 +186,7 @@ class BotFrameworkDriver extends Driver
      */
     public function isConfigured()
     {
-        return ! is_null($this->config->get('microsoft_app_id')) && ! is_null($this->config->get('microsoft_app_key'));
+        return ! empty($this->config->get('microsoft_app_id')) && ! empty($this->config->get('microsoft_app_key'));
     }
 
     /**

--- a/src/Mpociot/BotMan/Drivers/FacebookDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FacebookDriver.php
@@ -216,7 +216,7 @@ class FacebookDriver extends Driver
      */
     public function isConfigured()
     {
-        return ! is_null($this->config->get('facebook_token'));
+        return ! empty($this->config->get('facebook_token'));
     }
 
     /**

--- a/src/Mpociot/BotMan/Drivers/HipChatDriver.php
+++ b/src/Mpociot/BotMan/Drivers/HipChatDriver.php
@@ -103,7 +103,12 @@ class HipChatDriver extends Driver
      */
     public function isConfigured()
     {
-        $urls = array_filter($this->config->get('hipchat_urls'));
+        $urls = $this->config->get('hipchat_urls');
+
+        if (is_array($urls)) {
+            $urls = array_filter($urls);
+        }
+
         return ! empty($urls);
     }
 

--- a/src/Mpociot/BotMan/Drivers/HipChatDriver.php
+++ b/src/Mpociot/BotMan/Drivers/HipChatDriver.php
@@ -103,7 +103,8 @@ class HipChatDriver extends Driver
      */
     public function isConfigured()
     {
-        return ! empty($this->config->get('hipchat_urls'));
+        $urls = array_filter($this->config->get('hipchat_urls'));
+        return ! empty($urls);
     }
 
     /**

--- a/src/Mpociot/BotMan/Drivers/NexmoDriver.php
+++ b/src/Mpociot/BotMan/Drivers/NexmoDriver.php
@@ -104,7 +104,7 @@ class NexmoDriver extends Driver
      */
     public function isConfigured()
     {
-        return ! is_null($this->config->get('nexmo_key')) && ! is_null($this->config->get('nexmo_secret'));
+        return ! empty($this->config->get('nexmo_key')) && ! empty($this->config->get('nexmo_secret'));
     }
 
     /**

--- a/src/Mpociot/BotMan/Drivers/SlackDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackDriver.php
@@ -231,7 +231,7 @@ class SlackDriver extends Driver
      */
     public function isConfigured()
     {
-        return ! is_null($this->config->get('slack_token'));
+        return ! empty($this->config->get('slack_token'));
     }
 
     /**

--- a/src/Mpociot/BotMan/Drivers/TelegramDriver.php
+++ b/src/Mpociot/BotMan/Drivers/TelegramDriver.php
@@ -200,7 +200,7 @@ class TelegramDriver extends Driver
      */
     public function isConfigured()
     {
-        return ! is_null($this->config->get('telegram_token'));
+        return ! empty($this->config->get('telegram_token'));
     }
 
     /**

--- a/tests/Drivers/HipChatDriverTest.php
+++ b/tests/Drivers/HipChatDriverTest.php
@@ -216,5 +216,11 @@ class HipChatDriverTest extends PHPUnit_Framework_TestCase
         $driver = new HipChatDriver($request, [], $htmlInterface);
 
         $this->assertFalse($driver->isConfigured());
+
+        $driver = new HipChatDriver($request, [
+            'hipchat_urls' => [''],
+        ], $htmlInterface);
+
+        $this->assertFalse($driver->isConfigured());
     }
 }


### PR DESCRIPTION
In my case (botman starter kit), these values where an empty string, so detected as 'configured'.
In the case of Hipchat, it had 1 value in the array (also empty string), so filtered that out.