### PR TITLE
fix botframework not using shorthand closing tags

### DIFF
--- a/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
+++ b/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
@@ -41,8 +41,8 @@ class BotFrameworkDriver extends Driver
      */
     public function getConversationAnswer(Message $message)
     {
-        if (strstr($message->getMessage(), '<botman value="') !== false) {
-            preg_match('/<botman value="(.*)"\/>/', $message->getMessage(), $matches);
+        if (false !== strpos($message->getMessage(), '<botman value="')) {
+            preg_match('/<botman value="(.*)"><\/botman>/', $message->getMessage(), $matches);
 
             return Answer::create($message->getMessage())
                 ->setInteractiveReply(true)

--- a/tests/Drivers/BotFrameworkDriverTest.php
+++ b/tests/Drivers/BotFrameworkDriverTest.php
@@ -481,4 +481,22 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
         $message = $driver->getMessages()[0];
         $driver->reply(\Mpociot\BotMan\Messages\Message::create('Test')->video('http://foo.com/bar.mp4'), $message);
     }
+
+    /** @test */
+    public function it_interactive_responses_correctly()
+    {
+        $driver = $this->getDriver([
+            'event' => [
+                'user' => '29:2ZC81QtrQQti_yclfvcaNZnRgNSihIXUc6rgigeq82us',
+            ],
+        ]);
+
+        $text = 'I use botman with Skype<botman value="yes"></botman>';
+        $message = new Message($text, '29:2ZC81QtrQQti_yclfvcaNZnRgNSihIXUc6rgigeq82us', '29:2ZC81QtrQQti_yclfvcaNZnRgNSihIXUc6rgigeq82us');
+
+        $answer = $driver->getConversationAnswer($message);
+        $this->assertSame($text, $answer->getText());
+        $this->assertTrue($answer->isInteractiveMessageReply());
+        $this->assertSame('yes', $answer->getValue());
+    }
 }


### PR DESCRIPTION
Please see https://github.com/mpociot/botman/issues/344. Botframework conversations seems to be broken now.