### PR TITLE
Feature/stop and skip conv outside conv

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -29,6 +29,9 @@ class Command
     /** @var  boolean */
     protected $stopsConversation = false;
 
+    /** @var  boolean */
+    protected $skipsConversation = false;
+
     /**
      * Command constructor.
      * @param string $pattern
@@ -94,9 +97,27 @@ class Command
      *
      * @return bool
      */
-    public function shouldConversationStop()
+    public function shouldStopConversation()
     {
         return $this->stopsConversation;
+    }
+
+    /**
+     * With this command a current conversation should be stopped
+     */
+    public function skipsConversation()
+    {
+        $this->skipsConversation = true;
+    }
+
+    /**
+     * Tells if a current conversation should be skipped through this command
+     *
+     * @return bool
+     */
+    public function shouldSkipConversation()
+    {
+        return $this->skipsConversation;
     }
 
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -26,14 +26,15 @@ class Command
     /** @var array */
     protected $middleware = [];
 
-    /** @var  bool */
+    /** @var bool */
     protected $stopsConversation = false;
 
-    /** @var  bool */
+    /** @var bool */
     protected $skipsConversation = false;
 
     /**
      * Command constructor.
+     *
      * @param string $pattern
      * @param Closure|string $callback
      * @param string|null $recipient

--- a/src/Command.php
+++ b/src/Command.php
@@ -26,6 +26,9 @@ class Command
     /** @var array */
     protected $middleware = [];
 
+    /** @var  boolean */
+    protected $stopsConversation = false;
+
     /**
      * Command constructor.
      * @param string $pattern
@@ -76,6 +79,24 @@ class Command
         });
 
         return $this;
+    }
+
+    /**
+     * With this command a current conversation should be stopped
+     */
+    public function stopsConversation()
+    {
+        $this->stopsConversation = true;
+    }
+
+    /**
+     * Tells if a current conversation should be stopped through this command
+     *
+     * @return bool
+     */
+    public function shouldConversationStop()
+    {
+        return $this->stopsConversation;
     }
 
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -26,10 +26,10 @@ class Command
     /** @var array */
     protected $middleware = [];
 
-    /** @var  boolean */
+    /** @var  bool */
     protected $stopsConversation = false;
 
-    /** @var  boolean */
+    /** @var  bool */
     protected $skipsConversation = false;
 
     /**
@@ -85,7 +85,7 @@ class Command
     }
 
     /**
-     * With this command a current conversation should be stopped
+     * With this command a current conversation should be stopped.
      */
     public function stopsConversation()
     {
@@ -93,7 +93,7 @@ class Command
     }
 
     /**
-     * Tells if a current conversation should be stopped through this command
+     * Tells if a current conversation should be stopped through this command.
      *
      * @return bool
      */
@@ -103,7 +103,7 @@ class Command
     }
 
     /**
-     * With this command a current conversation should be stopped
+     * With this command a current conversation should be stopped.
      */
     public function skipsConversation()
     {
@@ -111,7 +111,7 @@ class Command
     }
 
     /**
-     * Tells if a current conversation should be skipped through this command
+     * Tells if a current conversation should be skipped through this command.
      *
      * @return bool
      */

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -3,7 +3,6 @@
 namespace Mpociot\BotMan\Traits;
 
 use Closure;
-use Illuminate\Support\Facades\Log;
 use Mpociot\BotMan\Message;
 use Mpociot\BotMan\Question;
 use Mpociot\BotMan\Conversation;
@@ -170,7 +169,7 @@ trait HandlesConversations
                             $this->cache->pull($message->getOriginatedConversationIdentifier());
 
                             return;
-                        } elseif($command->shouldSkipConversation()) {
+                        } elseif ($command->shouldSkipConversation()) {
                             return;
                         }
                     }

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -163,7 +163,6 @@ trait HandlesConversations
                     $pattern = $messageData['pattern'];
 
                     if (! $this->isBot() && $this->matcher->isMessageMatching($message, $this->getConversationAnswer()->getValue(), $pattern, $messageData['middleware'] + $this->middleware->heard()) && $this->matcher->isDriverValid($this->driver->getName(), $messageData['driver']) && $this->matcher->isRecipientValid($message->getRecipient(), $messageData['recipient']) && $this->loadedConversation === false) {
-
                         if ($command->shouldStopConversation()) {
                             $this->cache->pull($message->getConversationIdentifier());
                             $this->cache->pull($message->getOriginatedConversationIdentifier());

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -165,10 +165,12 @@ trait HandlesConversations
 
                     if (! $this->isBot() && $this->matcher->isMessageMatching($message, $this->getConversationAnswer()->getValue(), $pattern, $messageData['middleware'] + $this->middleware->heard()) && $this->matcher->isDriverValid($this->driver->getName(), $messageData['driver']) && $this->matcher->isRecipientValid($message->getRecipient(), $messageData['recipient']) && $this->loadedConversation === false) {
 
-                        if ($command->shouldConversationStop()) {
+                        if ($command->shouldStopConversation()) {
                             $this->cache->pull($message->getConversationIdentifier());
                             $this->cache->pull($message->getOriginatedConversationIdentifier());
 
+                            return;
+                        } elseif($command->shouldSkipConversation()) {
                             return;
                         }
                     }


### PR DESCRIPTION
Like discussed we want to use the `skip` and `stop` features for the hears method too like this:

```php
$botman->hears('stop', function(BotMan $bot) {
            $bot->reply('stopped');
})->stopsConversation();
```

It is already working but the implementation is very "rough". I also need some help with the test @mpociot :-) And how could we refactor the code? Maybe another method for the checks so we don't need the whole code there?