### PR TITLE
Only unserialize if it is not the SlackRTM or Console driver

### DIFF
--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -4,7 +4,6 @@ namespace Mpociot\BotMan;
 
 use Closure;
 use Illuminate\Support\Collection;
-use Mpociot\BotMan\Drivers\SlackRTMDriver;
 use Mpociot\BotMan\Interfaces\ShouldQueue;
 
 /**

--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -128,7 +128,7 @@ abstract class Conversation
             $next = unserialize($next)->getClosure();
         } elseif (is_array($next)) {
             $next = Collection::make($next)->map(function ($callback) {
-                if ($this->bot->getDriver()->getName() !== SlackRTMDriver::DRIVER_NAME) {
+                if ($this->bot->getDriver()->convCallbacksAreSerialized()) {
                     $callback['callback'] = unserialize($callback['callback'])->getClosure();
                 }
 

--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -12,6 +12,7 @@ use Mpociot\BotMan\Interfaces\ShouldQueue;
  */
 abstract class Conversation
 {
+
     /**
      * @var BotMan
      */
@@ -116,7 +117,7 @@ abstract class Conversation
     {
         $conversation = $this->bot->getStoredConversation();
 
-        if (! $question instanceof Question && ! $question) {
+        if ( ! $question instanceof Question && ! $question) {
             $question = unserialize($conversation['question']);
         }
 
@@ -127,7 +128,7 @@ abstract class Conversation
             $next = unserialize($next)->getClosure();
         } elseif (is_array($next)) {
             $next = Collection::make($next)->map(function ($callback) {
-                if($this->bot->getDriver()->getName() !== SlackRTMDriver::DRIVER_NAME) {
+                if ($this->bot->getDriver()->getName() !== SlackRTMDriver::DRIVER_NAME) {
                     $callback['callback'] = unserialize($callback['callback'])->getClosure();
                 }
 
@@ -180,7 +181,7 @@ abstract class Conversation
     public function __sleep()
     {
         $properties = get_object_vars($this);
-        if (! $this instanceof ShouldQueue) {
+        if ( ! $this instanceof ShouldQueue) {
             unset($properties['bot']);
         }
 

--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -12,7 +12,6 @@ use Mpociot\BotMan\Interfaces\ShouldQueue;
  */
 abstract class Conversation
 {
-
     /**
      * @var BotMan
      */
@@ -111,13 +110,14 @@ abstract class Conversation
 
     /**
      * Repeat the previously asked question.
+     *
      * @param string|Question $question
      */
     public function repeat($question = '')
     {
         $conversation = $this->bot->getStoredConversation();
 
-        if ( ! $question instanceof Question && ! $question) {
+        if (! $question instanceof Question && ! $question) {
             $question = unserialize($conversation['question']);
         }
 
@@ -152,6 +152,7 @@ abstract class Conversation
 
     /**
      * Should the conversation be skipped (temporarily).
+     *
      * @param  Message $message
      * @return bool
      */
@@ -162,6 +163,7 @@ abstract class Conversation
 
     /**
      * Should the conversation be removed and stopped (permanently).
+     *
      * @param  Message $message
      * @return bool
      */
@@ -181,7 +183,7 @@ abstract class Conversation
     public function __sleep()
     {
         $properties = get_object_vars($this);
-        if ( ! $this instanceof ShouldQueue) {
+        if (! $this instanceof ShouldQueue) {
             unset($properties['bot']);
         }
 

--- a/src/Mpociot/BotMan/Conversation.php
+++ b/src/Mpociot/BotMan/Conversation.php
@@ -4,6 +4,7 @@ namespace Mpociot\BotMan;
 
 use Closure;
 use Illuminate\Support\Collection;
+use Mpociot\BotMan\Drivers\SlackRTMDriver;
 use Mpociot\BotMan\Interfaces\ShouldQueue;
 
 /**
@@ -126,7 +127,9 @@ abstract class Conversation
             $next = unserialize($next)->getClosure();
         } elseif (is_array($next)) {
             $next = Collection::make($next)->map(function ($callback) {
-                $callback['callback'] = unserialize($callback['callback'])->getClosure();
+                if($this->bot->getDriver()->getName() !== SlackRTMDriver::DRIVER_NAME) {
+                    $callback['callback'] = unserialize($callback['callback'])->getClosure();
+                }
 
                 return $callback;
             })->toArray();

--- a/src/Mpociot/BotMan/Drivers/Driver.php
+++ b/src/Mpociot/BotMan/Drivers/Driver.php
@@ -79,6 +79,4 @@ abstract class Driver implements DriverInterface
     {
         return true;
     }
-
-
 }

--- a/src/Mpociot/BotMan/Drivers/Driver.php
+++ b/src/Mpociot/BotMan/Drivers/Driver.php
@@ -69,4 +69,16 @@ abstract class Driver implements DriverInterface
      * @return void
      */
     abstract public function sendRequest($endpoint, array $parameters, Message $matchingMessage);
+
+    /**
+     * Tells if the stored conversation callbacks are serialized.
+     *
+     * @return bool
+     */
+    public function convCallbacksAreSerialized()
+    {
+        return true;
+    }
+
+
 }

--- a/src/Mpociot/BotMan/Drivers/FakeDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FakeDriver.php
@@ -135,4 +135,14 @@ class FakeDriver implements DriverInterface
         $this->botIsTyping = false;
         $this->botMessages = [];
     }
+
+    /**
+     * Tells if the stored conversation callbacks are serialized.
+     *
+     * @return bool
+     */
+    public function convCallbacksAreSerialized()
+    {
+        return false;
+    }
 }

--- a/src/Mpociot/BotMan/Drivers/ProxyDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ProxyDriver.php
@@ -83,4 +83,14 @@ final class ProxyDriver implements DriverInterface
     {
         return self::instance()->types($matchingMessage);
     }
+
+    /**
+     * Tells if the stored conversation callbacks are serialized.
+     *
+     * @return bool
+     */
+    public function convCallbacksAreSerialized()
+    {
+        return false;
+    }
 }

--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -259,4 +259,14 @@ class SlackRTMDriver implements DriverInterface
     {
         return $this->client->apiCall($endpoint, $parameters, false, false);
     }
+
+    /**
+     * Tells if the stored conversation callbacks are serialized.
+     *
+     * @return bool
+     */
+    public function convCallbacksAreSerialized()
+    {
+        return false;
+    }
 }

--- a/src/Mpociot/BotMan/Interfaces/DriverInterface.php
+++ b/src/Mpociot/BotMan/Interfaces/DriverInterface.php
@@ -66,4 +66,11 @@ interface DriverInterface
      * @return mixed
      */
     public function types(Message $matchingMessage);
+
+    /**
+     * Tells if the stored conversation callbacks are serialized.
+     *
+     * @return bool
+     */
+    public function convCallbacksAreSerialized();
 }

--- a/tests/Drivers/FakeDriverTest.php
+++ b/tests/Drivers/FakeDriverTest.php
@@ -140,6 +140,14 @@ class FakeDriverTest extends PHPUnit_Framework_TestCase
         static::assertEquals(['Who are you?', 'Hello, Helloman'], $this->fakeDriver->getBotMessages());
     }
 
+    /**
+     * @test
+     **/
+    public function it_returns_false_for_check_if_conv_callbacks_are_stored_serialized()
+    {
+    	$this->assertFalse($this->fakeDriver->convCallbacksAreSerialized());
+    }
+
     private function listenToFakeMessage($message, $username, $channel)
     {
         $this->fakeDriver->messages = [new Message($message, $username, $channel)];

--- a/tests/Drivers/FakeDriverTest.php
+++ b/tests/Drivers/FakeDriverTest.php
@@ -145,7 +145,7 @@ class FakeDriverTest extends PHPUnit_Framework_TestCase
      **/
     public function it_returns_false_for_check_if_conv_callbacks_are_stored_serialized()
     {
-    	$this->assertFalse($this->fakeDriver->convCallbacksAreSerialized());
+        $this->assertFalse($this->fakeDriver->convCallbacksAreSerialized());
     }
 
     private function listenToFakeMessage($message, $username, $channel)

--- a/tests/Drivers/SlackRTMDriverTest.php
+++ b/tests/Drivers/SlackRTMDriverTest.php
@@ -128,4 +128,12 @@ class SlackRTMDriverTest extends PHPUnit_Framework_TestCase
 
         $driver->reply($message, $matchingMessage);
     }
+
+    /**
+     * @test
+     **/
+    public function it_returns_false_for_check_if_conv_callbacks_are_stored_serialized()
+    {
+        $this->assertFalse($this->fakeDriver->convCallbacksAreSerialized());
+    }
 }

--- a/tests/Fixtures/TestDriver.php
+++ b/tests/Fixtures/TestDriver.php
@@ -98,4 +98,14 @@ class TestDriver implements DriverInterface
     {
         return new User();
     }
+
+    /**
+     * Tells if the stored conversation callbacks are serialized.
+     *
+     * @return bool
+     */
+    public function convCallbacksAreSerialized()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixing #386 where BotMan tries to unserialise a not serialized callback. You wanted to reuse the `unserializeClosure` method from the HandlesConversations trait, but I wasn't sure how to use that in the Conversation class. Feel free to tell how to optimise it.