### PR TITLE
Fix typesAndWaits for Facebook

### DIFF
--- a/src/Drivers/Facebook/FacebookDriver.php
+++ b/src/Drivers/Facebook/FacebookDriver.php
@@ -157,7 +157,7 @@ class FacebookDriver extends Driver
     {
         $parameters = [
             'recipient' => [
-                'id' => $matchingMessage->getRecipient(),
+                'id' => $matchingMessage->getSender(),
             ],
             'access_token' => $this->config->get('facebook_token'),
             'sender_action' => 'typing_on',


### PR DESCRIPTION
Types method is using the wrong ID to send the API call.