### PR TITLE
hotfix: fix phpdoc on reply

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -489,7 +489,7 @@ class BotMan
     }
 
     /**
-     * @param string|Question $message
+     * @param string|\JsonSerializable $message
      * @param array $additionalParameters
      * @return mixed
      */


### PR DESCRIPTION
The $message could be a custom type of question.

I think that an interface for all the question's could be better.