### PR TITLE
[Telegram] avoids crash when trying to download attachments larger than 20 MB

### DIFF
--- a/src/Drivers/Telegram/TelegramAudioDriver.php
+++ b/src/Drivers/Telegram/TelegramAudioDriver.php
@@ -49,14 +49,14 @@ class TelegramAudioDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-	    // In case of file too large, this return only the attachment with the original payload, not the link.
-	    // This need a proper logging and exception system in the future
-	    $url = null;
-	    if (isset($path->result)) {
-		    $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
-	    }
+        // In case of file too large, this return only the attachment with the original payload, not the link.
+        // This need a proper logging and exception system in the future
+        $url = null;
+        if (isset($path->result)) {
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+        }
 
-	    return [new Audio($url, $audio),];
+        return [new Audio($url, $audio)];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramAudioDriver.php
+++ b/src/Drivers/Telegram/TelegramAudioDriver.php
@@ -49,10 +49,14 @@ class TelegramAudioDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-        return [
-            new Audio('https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path,
-                $audio),
-        ];
+	    // In case of file too large, this return only the attachment with the original payload, not the link.
+	    // This need a proper logging and exception system in the future
+	    $url = null;
+	    if (isset($path->result)) {
+		    $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+	    }
+
+	    return [new Audio($url, $audio),];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramFileDriver.php
+++ b/src/Drivers/Telegram/TelegramFileDriver.php
@@ -47,16 +47,14 @@ class TelegramFileDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-        // In case of file too large, don't return anything
+        // In case of file too large, this return only the attachment with the original payload, not the link.
 	    // This need a proper logging and exception system in the future
-        if (!isset($path->result)) {
-        	return [];
+	    $url = null;
+        if (isset($path->result)) {
+        	$url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
         }
 
-        return [
-            new File('https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path,
-                $file),
-        ];
+        return [new File($url, $file),];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramFileDriver.php
+++ b/src/Drivers/Telegram/TelegramFileDriver.php
@@ -47,6 +47,12 @@ class TelegramFileDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
+        // In case of file too large, don't return anything
+	    // This need a proper logging and exception system in the future
+        if (!isset($path->result)) {
+        	return [];
+        }
+
         return [
             new File('https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path,
                 $file),

--- a/src/Drivers/Telegram/TelegramFileDriver.php
+++ b/src/Drivers/Telegram/TelegramFileDriver.php
@@ -48,13 +48,13 @@ class TelegramFileDriver extends TelegramDriver
         $path = json_decode($response->getContent());
 
         // In case of file too large, this return only the attachment with the original payload, not the link.
-	    // This need a proper logging and exception system in the future
-	    $url = null;
+        // This need a proper logging and exception system in the future
+        $url = null;
         if (isset($path->result)) {
-        	$url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
         }
 
-        return [new File($url, $file),];
+        return [new File($url, $file)];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramPhotoDriver.php
+++ b/src/Drivers/Telegram/TelegramPhotoDriver.php
@@ -48,10 +48,14 @@ class TelegramPhotoDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-        return [
-            new Image('https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path,
-                $largetstPhoto),
-        ];
+	    // In case of file too large, this return only the attachment with the original payload, not the link.
+	    // This need a proper logging and exception system in the future
+	    $url = null;
+	    if (isset($path->result)) {
+		    $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+	    }
+
+	    return [new Image($url, $largetstPhoto)];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramPhotoDriver.php
+++ b/src/Drivers/Telegram/TelegramPhotoDriver.php
@@ -48,14 +48,14 @@ class TelegramPhotoDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-	    // In case of file too large, this return only the attachment with the original payload, not the link.
-	    // This need a proper logging and exception system in the future
-	    $url = null;
-	    if (isset($path->result)) {
-		    $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
-	    }
+        // In case of file too large, this return only the attachment with the original payload, not the link.
+        // This need a proper logging and exception system in the future
+        $url = null;
+        if (isset($path->result)) {
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+        }
 
-	    return [new Image($url, $largetstPhoto)];
+        return [new Image($url, $largetstPhoto)];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramVideoDriver.php
+++ b/src/Drivers/Telegram/TelegramVideoDriver.php
@@ -46,10 +46,14 @@ class TelegramVideoDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-        return [
-            new Video('https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path,
-                $video),
-        ];
+	    // In case of file too large, this return only the attachment with the original payload, not the link.
+	    // This need a proper logging and exception system in the future
+	    $url = null;
+	    if (isset($path->result)) {
+		    $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+	    }
+
+	    return [new Video($url, $video)];
     }
 
     /**

--- a/src/Drivers/Telegram/TelegramVideoDriver.php
+++ b/src/Drivers/Telegram/TelegramVideoDriver.php
@@ -46,14 +46,14 @@ class TelegramVideoDriver extends TelegramDriver
 
         $path = json_decode($response->getContent());
 
-	    // In case of file too large, this return only the attachment with the original payload, not the link.
-	    // This need a proper logging and exception system in the future
-	    $url = null;
-	    if (isset($path->result)) {
-		    $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
-	    }
+        // In case of file too large, this return only the attachment with the original payload, not the link.
+        // This need a proper logging and exception system in the future
+        $url = null;
+        if (isset($path->result)) {
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+        }
 
-	    return [new Video($url, $video)];
+        return [new Video($url, $video)];
     }
 
     /**


### PR DESCRIPTION
This avoid an internal server error when you try to download files that are more than 20 MB.

Now in case of an error, the download url for the attachment will be null.