### PR TITLE
DialogFlow Allow reset contexts

### DIFF
--- a/src/Middleware/ApiAi.php
+++ b/src/Middleware/ApiAi.php
@@ -19,7 +19,7 @@ class ApiAi implements MiddlewareInterface
     /** @var HttpInterface */
     protected $http;
 
-    /** @var \stdClass */
+    /** @var stdClass */
     protected $response;
 
     /** @var string */
@@ -37,11 +37,12 @@ class ApiAi implements MiddlewareInterface
      * @param string $lang language
      * @param HttpInterface $http
      */
-    public function __construct($token, HttpInterface $http, $lang = 'en')
+    public function __construct($token, HttpInterface $http, $lang, $resetContexts)
     {
         $this->token = $token;
-        $this->lang = $lang;
         $this->http = $http;
+        $this->lang = $lang ?: 'en';
+        $this->resetContexts = $resetContexts ?: false;
     }
 
     /**
@@ -50,9 +51,9 @@ class ApiAi implements MiddlewareInterface
      * @param string $lang language
      * @return ApiAi
      */
-    public static function create($token, $lang = 'en')
+    public static function create($token, $lang = 'en', $resetContexts = false)
     {
-        return new static($token, new Curl(), $lang);
+        return new static($token, new Curl(), $lang, $resetContexts);
     }
 
     /**
@@ -70,7 +71,7 @@ class ApiAi implements MiddlewareInterface
     /**
      * Perform the API.ai API call and cache it for the message.
      * @param  \BotMan\BotMan\Messages\Incoming\IncomingMessage $message
-     * @return \stdClass
+     * @return stdClass
      */
     protected function getResponse(IncomingMessage $message)
     {
@@ -78,6 +79,7 @@ class ApiAi implements MiddlewareInterface
             'query' => [$message->getText()],
             'sessionId' => md5($message->getConversationIdentifier()),
             'lang' => $this->lang,
+            'resetContexts' => $this->resetContexts,
         ], [
             'Authorization: Bearer '.$this->token,
             'Content-Type: application/json; charset=utf-8',
@@ -115,10 +117,10 @@ class ApiAi implements MiddlewareInterface
     {
         $response = $this->getResponse($message);
 
-        $reply = $response->result->fulfillment->speech ?? '';
-        $action = $response->result->action ?? '';
+        $reply = isset($response->result->fulfillment->speech) ? $response->result->fulfillment->speech : '';
+        $action = isset($response->result->action) ? $response->result->action : '';
         $actionIncomplete = isset($response->result->actionIncomplete) ? (bool) $response->result->actionIncomplete : false;
-        $intent = $response->result->metadata->intentName ?? '';
+        $intent = isset($response->result->metadata->intentName) ? $response->result->metadata->intentName : '';
         $parameters = isset($response->result->parameters) ? (array) $response->result->parameters : [];
 
         $message->addExtras('apiReply', $reply);

--- a/src/Middleware/ApiAi.php
+++ b/src/Middleware/ApiAi.php
@@ -31,18 +31,20 @@ class ApiAi implements MiddlewareInterface
     /** @var bool */
     protected $listenForAction = false;
 
+    /** @var bool */
+    protected $resetContexts = false;
+
     /**
      * Wit constructor.
      * @param string $token api.ai access token
      * @param string $lang language
      * @param HttpInterface $http
      */
-    public function __construct($token, HttpInterface $http, $lang, $resetContexts)
+    public function __construct($token, HttpInterface $http, $lang = 'en')
     {
         $this->token = $token;
+        $this->lang = $lang;
         $this->http = $http;
-        $this->lang = $lang ?: 'en';
-        $this->resetContexts = $resetContexts ?: false;
     }
 
     /**
@@ -51,9 +53,9 @@ class ApiAi implements MiddlewareInterface
      * @param string $lang language
      * @return ApiAi
      */
-    public static function create($token, $lang = 'en', $resetContexts = false)
+    public static function create($token, $lang = 'en')
     {
-        return new static($token, new Curl(), $lang, $resetContexts);
+        return new static($token, new Curl(), $lang);
     }
 
     /**
@@ -66,6 +68,14 @@ class ApiAi implements MiddlewareInterface
         $this->listenForAction = $listen;
 
         return $this;
+    }
+
+    /**
+     * Set Reset Contexts Flag.
+     */
+    public function setResetContexts(bool $value)
+    {
+        $this->resetContexts = $value;
     }
 
     /**

--- a/tests/Middleware/ApiAiTest.php
+++ b/tests/Middleware/ApiAiTest.php
@@ -51,6 +51,7 @@ class ApiAiTest extends TestCase
                 'query' => [$messageText],
                 'sessionId' => md5($message->getConversationIdentifier()),
                 'lang' => 'en',
+                'resetContexts' => false,
             ], [
                 'Authorization: Bearer token',
                 'Content-Type: application/json; charset=utf-8',


### PR DESCRIPTION
Currently there is no way to reset the context of Dialogflow after matching intent.

```php
/*
 * DialogFlow start lissening here
 * -----------------------------------------------------------------------------
 */
$dialogflow = Dialogflow::create(env('DIALOGFLOW_TOKEN'))->listenForAction();
$dialogflow->setResetContexts(true); // We don't want to remember the context between requests.
$botman->middleware->received($dialogflow);
```