### PR TITLE
Guzzle HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,15 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.1",
         "doctrine/cache": "^1.6",
         "symfony/cache": "^3.1",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "guzzlehttp/guzzle": "^6.3",
+        "symfony/psr-http-message-bridge": "^1.0"
     },
     "suggest": {
         "doctrine/cache": "Use any Doctrine cache driver for cache",
-        "symfony/cache": "Use any Symfony cache driver for cache"
+        "symfony/cache": "Use any Symfony cache driver for cache",
+        "guzzlehttp/guzzle": "Use Guzzle as a HTTP client",
+        "symfony/psr-http-message-bridge": "PSR-7 bridge for HttpFoundation"
     },
     "autoload": {
         "psr-4": {

--- a/src/Http/Guzzle.php
+++ b/src/Http/Guzzle.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace BotMan\BotMan\Http;
+
+use BotMan\BotMan\Interfaces\HttpInterface;
+use GuzzleHttp\Client;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\Response;
+
+class Guzzle implements HttpInterface
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * Converts PSR-7 response to HttpFoundation response.
+     *
+     * @var HttpFoundationFactory
+     */
+    private $factory;
+
+    public function __construct(Client $client, HttpFoundationFactory $httpFactory)
+    {
+        $this->client = $client;
+        $this->factory = $httpFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(
+        $url,
+        array $urlParameters = [],
+        array $headers = [],
+        $asJSON = false
+    ): Response {
+        $psrResponse = $this->client->get($url, [
+            'headers' => $headers,
+            'http_errors' => false,
+            'query' => $urlParameters
+        ]);
+
+        return $this->factory->createResponse($psrResponse);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function post(
+        $url,
+        array $urlParameters = [],
+        array $postParameters = [],
+        array $headers = [],
+        $asJSON = false
+    ): Response {
+        $options = [
+            'headers' => $headers,
+            'http_errors' => false,
+            'query' => $urlParameters
+        ];
+
+        $postKey = $asJSON ? 'json' : 'form_params';
+        $options[$postKey] = $postParameters;
+
+        $psrResponse = $this->client->post($url, $options);
+
+        return $this->factory->createResponse($psrResponse);
+    }
+}

--- a/tests/Http/GuzzleTest.php
+++ b/tests/Http/GuzzleTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace BotMan\BotMan\Tests\Http;
+
+use BotMan\BotMan\Http\Guzzle;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+
+class GuzzleTest extends TestCase
+{
+    /**
+     * @var MockHandler
+     */
+    private $mockHandler;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var Guzzle
+     */
+    private $guzzle;
+
+    public function setUp()
+    {
+        $this->mockHandler = new MockHandler();
+        $this->client = new Client(['handler' => $this->mockHandler]);
+        $this->guzzle = new Guzzle($this->client, new HttpFoundationFactory());
+    }
+
+    /** @test */
+    public function it_can_send_get_request_with_headers_and_query_string()
+    {
+        $body = '{
+          "args": {
+            "param1": "1", 
+            "param2": "2"
+          }, 
+          "headers": {
+            "Accept": "application/json", 
+            "Connection": "close", 
+            "Host": "httpbin.org", 
+            "User-Agent": "GuzzleHttp/6.3.3 curl/7.47.0 PHP/7.1.18-1+ubuntu16.04.1+deb.sury.org+1"
+          },
+          "url": "http://httpbin.org/get?param1=1&param2=2"
+        }';
+        $this->mockHandler->append(new Response(200, [], $body));
+
+        $headers = ['Accept' => 'application/json'];
+        $urlParameters = ['param1' => 1, 'param2' => 2];
+        $response = $this->guzzle->get('http://httpbin.org/get', $urlParameters, $headers);
+
+        $responseArray = json_decode($response->getContent(), true);
+        $this->assertEquals('application/json', $responseArray['headers']['Accept']);
+        $this->assertEquals(1, $responseArray['args']['param1']);
+        $this->assertEquals(2, $responseArray['args']['param2']);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function it_does_not_throw_on_errors()
+    {
+        $this->mockHandler->append(new Response(404, [], 'Not found'));
+        $this->mockHandler->append(new Response(500, [], 'Internal error'));
+
+        $response = $this->guzzle->get('http://httpbin.org/status/404');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->guzzle->get('http://httpbin.org/status/500');
+        $this->assertEquals(500, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function it_can_send_post_request()
+    {
+        $body = '{
+          "args": {
+            "get_param": "1"
+          }, 
+          "data": "", 
+          "files": {}, 
+          "form": {
+            "post_param": "2"
+          }, 
+          "headers": {
+            "Accept": "application/json", 
+            "Connection": "close", 
+            "Content-Length": "12", 
+            "Content-Type": "application/x-www-form-urlencoded", 
+            "Host": "httpbin.org", 
+            "User-Agent": "GuzzleHttp/6.3.3 curl/7.47.0 PHP/7.1.18-1+ubuntu16.04.1+deb.sury.org+1"
+          }, 
+          "url": "http://httpbin.org/post?get_param=1"
+        }';
+        $this->mockHandler->append(new Response(200, [], $body));
+
+        $headers = ['Accept' => 'application/json'];
+        $urlParameters = ['get_param' => 1];
+        $postParameters = ['post_param' => 2];
+        $response = $this->guzzle->post('http://httpbin.org/post', $urlParameters, $postParameters, $headers);
+
+        $responseArray = json_decode($response->getContent(), true);
+        $this->assertEquals('application/json', $responseArray['headers']['Accept']);
+        $this->assertEquals(1, $responseArray['args']['get_param']);
+        $this->assertEquals(2, $responseArray['form']['post_param']);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function it_can_send_post_request_as_json()
+    {
+        $body = '{
+          "args": {
+            "get_param": "1"
+          }, 
+          "data": "{\"post_param\":2}", 
+          "files": {}, 
+          "form": {}, 
+          "headers": {
+            "Accept": "application/json", 
+            "Connection": "close", 
+            "Content-Length": "16", 
+            "Content-Type": "application/json", 
+            "Host": "httpbin.org", 
+            "User-Agent": "GuzzleHttp/6.3.3 curl/7.47.0 PHP/7.1.18-1+ubuntu16.04.1+deb.sury.org+1"
+          }, 
+          "json": {
+            "post_param": 2
+          }, 
+          "url": "http://httpbin.org/post?get_param=1"
+        }';
+        $this->mockHandler->append(new Response(200, [], $body));
+
+        $headers = ['Accept' => 'application/json'];
+        $urlParameters = ['get_param' => 1];
+        $postParameters = ['post_param' => 2];
+        $asJson = true;
+        $response = $this->guzzle->post('http://httpbin.org/post', $urlParameters, $postParameters, $headers, $asJson);
+
+        $responseArray = json_decode($response->getContent(), true);
+        $this->assertEquals('application/json', $responseArray['headers']['Accept']);
+        $this->assertEquals(1, $responseArray['args']['get_param']);
+        $this->assertEquals(2, $responseArray['json']['post_param']);
+        $this->assertEmpty($responseArray['form']);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/botman/driver-telegram/issues/46

This PR adds an optional Guzzle adapter for `BotMan\BotMan\Interfaces\HttpInterface`: https://github.com/botman/botman/blob/2.0/src/Interfaces/HttpInterface.php

Guzzle is pretty much the de facto standard for making HTTP requests in PHP these days. It allows to configure proxy using constructor: http://docs.guzzlephp.org/en/stable/request-options.html#proxy

I think it is important to document how to use Guzzle HTTP client in the docs. Can make a PR in the docs repository which describes how to configure Guzzle.

Required steps to use Guzzle HTTP client:
1) Run `composer require guzzlehttp/guzzle symfony/psr-http-message-bridge`
2) Manually register BotMan class and drivers with `BotMan\BotMan\Http\Guzzle` instead of `BotMan\BotMan\Http\Curl`