### PR TITLE
Matching middleware can use the Matcher instance and alter matches field.

### DIFF
--- a/src/Interfaces/Middleware/Matching.php
+++ b/src/Interfaces/Middleware/Matching.php
@@ -3,6 +3,7 @@
 namespace BotMan\BotMan\Interfaces\Middleware;
 
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 interface Matching
 {
@@ -10,7 +11,8 @@ interface Matching
      * @param IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param bool $matcher The current Matcher instance
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched);
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher);
 }

--- a/src/Interfaces/Middleware/Matching.php
+++ b/src/Interfaces/Middleware/Matching.php
@@ -11,7 +11,7 @@ interface Matching
      * @param IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
-     * @param bool $matcher The current Matcher instance
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
     public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher);

--- a/src/Messages/Matcher.php
+++ b/src/Messages/Matcher.php
@@ -58,12 +58,14 @@ class Matcher
 
         // Try middleware first
         if (count($middleware)) {
+            $matcher=$this;
             return Collection::make($middleware)->reject(function (Matching $middleware) use (
                     $message,
                     $pattern,
-                    $regexMatched
+                    $regexMatched,
+                    $matcher
                 ) {
-                return $middleware->matching($message, $pattern, $regexMatched);
+                return $middleware->matching($message, $pattern, $regexMatched, $matcher);
             })->isEmpty() === true;
         }
 

--- a/src/Middleware/ApiAi.php
+++ b/src/Middleware/ApiAi.php
@@ -7,6 +7,7 @@ use BotMan\BotMan\Http\Curl;
 use BotMan\BotMan\Interfaces\HttpInterface;
 use BotMan\BotMan\Interfaces\MiddlewareInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 class ApiAi implements MiddlewareInterface
 {
@@ -136,7 +137,7 @@ class ApiAi implements MiddlewareInterface
      * @param bool $regexMatched Indicator if the regular expression was matched too
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         if ($this->listenForAction) {
             $pattern = '/^'.$pattern.'$/i';

--- a/src/Middleware/ApiAi.php
+++ b/src/Middleware/ApiAi.php
@@ -135,6 +135,7 @@ class ApiAi implements MiddlewareInterface
      * @param \BotMan\BotMan\Messages\Incoming\IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
     public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)

--- a/src/Middleware/Wit.php
+++ b/src/Middleware/Wit.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use BotMan\BotMan\Interfaces\HttpInterface;
 use BotMan\BotMan\Interfaces\MiddlewareInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 class Wit implements MiddlewareInterface
 {
@@ -97,7 +98,7 @@ class Wit implements MiddlewareInterface
      * @param bool $regexMatched Indicator if the regular expression was matched too
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         $entities = Collection::make($message->getExtras())->get('entities', []);
 

--- a/src/Middleware/Wit.php
+++ b/src/Middleware/Wit.php
@@ -96,6 +96,7 @@ class Wit implements MiddlewareInterface
      * @param \BotMan\BotMan\Messages\Incoming\IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
     public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)

--- a/tests/Fixtures/Middleware/Matching.php
+++ b/tests/Fixtures/Middleware/Matching.php
@@ -4,6 +4,7 @@ namespace BotMan\BotMan\Tests\Fixtures\Middleware;
 
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Interfaces\Middleware\Matching as MatchingInterface;
+use BotMan\BotMan\Messages\Matcher;
 
 class Matching implements MatchingInterface
 {
@@ -11,9 +12,10 @@ class Matching implements MatchingInterface
      * @param IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         return $message->getText()[0] === 'o';
     }

--- a/tests/Fixtures/TestCustomMiddleware.php
+++ b/tests/Fixtures/TestCustomMiddleware.php
@@ -6,6 +6,7 @@ use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Messages\Outgoing\Question;
 use BotMan\BotMan\Interfaces\MiddlewareInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 class TestCustomMiddleware implements MiddlewareInterface
 {
@@ -50,9 +51,10 @@ class TestCustomMiddleware implements MiddlewareInterface
      * @param \BotMan\BotMan\Messages\Incoming\IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         $_SERVER['middleware_matching'] = $message->getText().'-'.$pattern;
 

--- a/tests/Fixtures/TestMatchMiddleware.php
+++ b/tests/Fixtures/TestMatchMiddleware.php
@@ -5,6 +5,7 @@ namespace BotMan\BotMan\Tests\Fixtures;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Interfaces\MiddlewareInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 class TestMatchMiddleware implements MiddlewareInterface
 {
@@ -43,9 +44,10 @@ class TestMatchMiddleware implements MiddlewareInterface
      * @param IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         return true && $regexMatched;
     }

--- a/tests/Fixtures/TestMiddleware.php
+++ b/tests/Fixtures/TestMiddleware.php
@@ -5,6 +5,7 @@ namespace BotMan\BotMan\Tests\Fixtures;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Interfaces\MiddlewareInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 class TestMiddleware implements MiddlewareInterface
 {
@@ -43,9 +44,10 @@ class TestMiddleware implements MiddlewareInterface
      * @param \BotMan\BotMan\Messages\Incoming\IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         return $message->getExtras()['test'] == $pattern;
     }

--- a/tests/Fixtures/TestNoMatchMiddleware.php
+++ b/tests/Fixtures/TestNoMatchMiddleware.php
@@ -5,6 +5,7 @@ namespace BotMan\BotMan\Tests\Fixtures;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Interfaces\MiddlewareInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
 
 class TestNoMatchMiddleware implements MiddlewareInterface
 {
@@ -40,9 +41,10 @@ class TestNoMatchMiddleware implements MiddlewareInterface
      * @param \BotMan\BotMan\Messages\Incoming\IncomingMessage $message
      * @param string $pattern
      * @param bool $regexMatched Indicator if the regular expression was matched too
+     * @param Matcher $matcher The current Matcher instance
      * @return bool
      */
-    public function matching(IncomingMessage $message, $pattern, $regexMatched)
+    public function matching(IncomingMessage $message, $pattern, $regexMatched, Matcher $matcher)
     {
         return false;
     }

--- a/tests/Middleware/ApiAiTest.php
+++ b/tests/Middleware/ApiAiTest.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\BotMan\tests\Middleware;
 
+use BotMan\BotMan\Messages\Matcher;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Http\Curl;
@@ -104,8 +105,8 @@ class ApiAiTest extends TestCase
         $middleware = new ApiAi('token', $http);
         $middleware->listenForAction();
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertTrue($middleware->matching($message, $messageText, false));
-        $this->assertFalse($middleware->matching($message, 'some_other_action', false));
+        $this->assertTrue($middleware->matching($message, $messageText, false, new Matcher()));
+        $this->assertFalse($middleware->matching($message, 'some_other_action', false, new Matcher()));
     }
 
     /** @test */
@@ -139,8 +140,8 @@ class ApiAiTest extends TestCase
         $middleware = new ApiAi('token', $http);
         $middleware->listenForAction();
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertTrue($middleware->matching($message, $messageText, false));
-        $this->assertFalse($middleware->matching($message, 'some_other_action', false));
+        $this->assertTrue($middleware->matching($message, $messageText, false, new Matcher()));
+        $this->assertFalse($middleware->matching($message, 'some_other_action', false, new Matcher()));
     }
 
     /** @test */

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\BotMan\tests\Middleware;
 
+use BotMan\BotMan\Messages\Matcher;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Http\Curl;
@@ -90,7 +91,7 @@ class WitTest extends TestCase
 
         $middleware = new Wit('token', 0.5, $http);
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertTrue($middleware->matching($message, 'emotion', false));
+        $this->assertTrue($middleware->matching($message, 'emotion', false, new Matcher()));
     }
 
     /** @test */
@@ -134,7 +135,7 @@ class WitTest extends TestCase
 
         $middleware = new Wit('token', 0.5, $http);
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertFalse($middleware->matching($message, 'emotion', false));
+        $this->assertFalse($middleware->matching($message, 'emotion', false, new Matcher()));
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #913 

Matching middlewares can now alter Matcher fields (matches) as it receive the Matcher instance as parameter too.