### PR TITLE
Import facade instead of class alias

### DIFF
--- a/src/Cache/LaravelCache.php
+++ b/src/Cache/LaravelCache.php
@@ -2,7 +2,7 @@
 
 namespace BotMan\BotMan\Cache;
 
-use Cache;
+use Illuminate\Support\Facades\Cache;
 use BotMan\BotMan\Interfaces\CacheInterface;
 
 /**


### PR DESCRIPTION
Fixes #1039

The `use Cache;` points to the alias that Laravel comes with, but this class alias doesn't have to exist and it is thus safer to use the FQCN of the Facade.