### PR TITLE
Import facade instead of class alias

### DIFF
--- a/src/Cache/LaravelCache.php
+++ b/src/Cache/LaravelCache.php
@@ -2,8 +2,8 @@
 
 namespace BotMan\BotMan\Cache;
 
+use Illuminate\Support\Facades\Cache;;
 use BotMan\BotMan\Interfaces\CacheInterface;
-use Cache;
 
 /**
  * The Laravel Cache implementation.


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The use Cache; points to the alias that Laravel comes with, but this class alias doesn't have to exist and it is thus safer to use the FQCN of the Facade.

* **Other information**:
Closes #1052 
Fixes #1039 