### PR TITLE
Fixed Mockery Expectation where HttpInterface is using GET rather than POST.

### DIFF
--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -30,9 +30,9 @@ class WitTest extends TestCase
         $response = new Response(json_encode(['entities' => ['foo' => 'bar']]));
 
         $http = m::mock(Curl::class);
-        $http->shouldReceive('post')
+        $http->shouldReceive('get')
             ->once()
-            ->with('https://api.wit.ai/message?q='.urlencode($messageText), [], [], [
+            ->with('https://api.wit.ai/message?q='.urlencode($messageText), [], [
                 'Authorization: Bearer token',
             ])
             ->andReturn($response);
@@ -77,9 +77,9 @@ class WitTest extends TestCase
         ');
 
         $http = m::mock(Curl::class);
-        $http->shouldReceive('post')
+        $http->shouldReceive('get')
             ->once()
-            ->with('https://api.wit.ai/message?q='.urlencode($messageText), [], [], [
+            ->with('https://api.wit.ai/message?q='.urlencode($messageText), [], [
                 'Authorization: Bearer token',
             ])
             ->andReturn($response);
@@ -121,9 +121,9 @@ class WitTest extends TestCase
         ');
 
         $http = m::mock(Curl::class);
-        $http->shouldReceive('post')
+        $http->shouldReceive('get')
             ->once()
-            ->with('https://api.wit.ai/message?q='.urlencode($messageText), [], [], [
+            ->with('https://api.wit.ai/message?q='.urlencode($messageText), [], [
                 'Authorization: Bearer token',
             ])
             ->andReturn($response);
@@ -153,7 +153,7 @@ class WitTest extends TestCase
         $botman = BotManFactory::create([], new ArrayCache, $request);
 
         $http = m::mock(Curl::class);
-        $http->shouldReceive('post')
+        $http->shouldReceive('get')
             ->once()
             ->andReturn(new Response('[]'));
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**

Mockery method call expectation fix.


* **What is the current behavior?**

If you run `phpunit tests/Middleware/WitTest.php` the test will fail does Travis fails.

![image](https://user-images.githubusercontent.com/2193300/83352490-51b14400-a37e-11ea-9bef-04764db9e17e.png)


* **What is the new behavior?**

This is just an expectation fix for the mockery. If you run again `phpunit tests/Middleware/WitTest.php`

![image](https://user-images.githubusercontent.com/2193300/83352510-7f968880-a37e-11ea-9123-3311105b9d9a.png)


* **Does this PR introduce a breaking change?**

None at all.


* **Other information**:
