### PR TITLE
Update wit middleware. #1186

### DIFF
--- a/src/Middleware/Wit.php
+++ b/src/Middleware/Wit.php
@@ -87,6 +87,7 @@ class Wit implements MiddlewareInterface
 
         $responseData = Collection::make(json_decode($response->getContent(), true));
         $message->addExtras('entities', $responseData->get('entities'));
+        $message->addExtras('intents', $responseData->get('intents'));
 
         return $next($message);
     }
@@ -99,16 +100,12 @@ class Wit implements MiddlewareInterface
      */
     public function matching(IncomingMessage $message, $pattern, $regexMatched)
     {
-        $entities = Collection::make($message->getExtras())->get('entities', []);
+        $intents = Collection::make($message->getExtras())->get('intents', []);
 
-        if (! empty($entities)) {
-            foreach ($entities as $name => $entity) {
-                if ($name === 'intent') {
-                    foreach ($entity as $item) {
-                        if ($item['value'] === $pattern && $item['confidence'] >= $this->minimumConfidence) {
-                            return true;
-                        }
-                    }
+        if (!empty($intents)) {
+            foreach ($intents as $intent) {
+                if (($intent['name'] === $pattern || $intent['id'] === $pattern) && $intent['confidence'] >= $this->minimumConfidence) {
+                    return true;
                 }
             }
         }

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -27,7 +27,7 @@ class WitTest extends TestCase
         $messageText = 'This will be my message text!';
         $message = new IncomingMessage($messageText, '', '');
 
-        $response = new Response(json_encode(['intents' => [], 'entities' => ['foo' => 'bar']]));
+        $response = new Response(json_encode(['entities' => ['foo' => 'bar'], 'intents' => []]));
 
         $http = m::mock(Curl::class);
         $http->shouldReceive('get')
@@ -45,8 +45,8 @@ class WitTest extends TestCase
         $middleware->received($message, $callback, m::mock(BotMan::class));
 
         $this->assertSame([
-            'intents' => [],
             'entities' => ['foo' => 'bar'],
+            'intents' => []
         ], $message->getExtras());
     }
 

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -27,7 +27,7 @@ class WitTest extends TestCase
         $messageText = 'This will be my message text!';
         $message = new IncomingMessage($messageText, '', '');
 
-        $response = new Response(json_encode(['entities' => ['foo' => 'bar']]));
+        $response = new Response(json_encode(['intents' => [], 'entities' => ['foo' => 'bar']]));
 
         $http = m::mock(Curl::class);
         $http->shouldReceive('get')
@@ -45,6 +45,7 @@ class WitTest extends TestCase
         $middleware->received($message, $callback, m::mock(BotMan::class));
 
         $this->assertSame([
+            'intents' => [],
             'entities' => ['foo' => 'bar'],
         ], $message->getExtras());
     }

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -58,18 +58,19 @@ class WitTest extends TestCase
         $response = new Response('{
           "msg_id": "eb458be1-43e0-47c0-88b2-efbc9fa3240a",
           "_text": "I am happy",
+          "intents": [
+            {
+              "id": "123456",
+              "name": "emotion",
+              "confidence": 0.7343395827157483
+            }
+          ],
           "entities": {
             "emotion": [
               {
                 "confidence": 0.9775576413827303,
                 "type": "value",
                 "value": "happy"
-              }
-            ],
-            "intent": [
-              {
-                "confidence": 0.7343395827157483,
-                "value": "emotion"
               }
             ]
           }
@@ -102,18 +103,19 @@ class WitTest extends TestCase
         $response = new Response('{
           "msg_id": "eb458be1-43e0-47c0-88b2-efbc9fa3240a",
           "_text": "I am happy",
+          "intents": [
+            {
+              "id": "123456",
+              "name": "emotion",
+              "confidence": 0.343395827157483,
+            }
+          ],
           "entities": {
             "emotion": [
               {
                 "confidence": 0.9775576413827303,
                 "type": "value",
                 "value": "happy"
-              }
-            ],
-            "intent": [
-              {
-                "confidence": 0.343395827157483,
-                "value": "emotion"
               }
             ]
           }


### PR DESCRIPTION
The actual system doesn't seems to be compatible with the actual response format from wit.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updating the wit.ai middleware as the json response from wit has changed. previously intents were parts of the 'entities', they now have their own key in the json response.


* **What is the current behavior?** (You can also link to an open issue here)
Wit middleware doesn't match anything as entities are empty, they don't contains the intents.


* **What is the new behavior (if this is a feature change)?**
Adding a new extras['intents'] in the message and we now are checking in the intents if there is a match. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change, the wit middleware should now work correctly. It's even adding a match on the intent id if the user wants to use it instead of the name.


* **Other information**:
Current tests should be updated with the new format of the wit.ai response if the maintainers confirms the change. (better like to be sure, i'm very surprised nobody mentioned / noticed this before)
