### PR TITLE
make OutgoingMessage return static instead of self

### DIFF
--- a/src/Messages/Outgoing/OutgoingMessage.php
+++ b/src/Messages/Outgoing/OutgoingMessage.php
@@ -30,7 +30,7 @@ class OutgoingMessage
      */
     public static function create($message = null, Attachment $attachment = null)
     {
-        return new self($message, $attachment);
+        return new static($message, $attachment);
     }
 
     /**


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature, I guess?


* **What is the current behavior?** (You can also link to an open issue here)
OngoingMessage returns instance of OngoingMessage even if the class was extended


* **What is the new behavior (if this is a feature change)?**
It will return an instance of a class it was called from


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
