### PR TITLE
Fix for cache intersecting between bots based on same application. Fixes #1132 and #1172

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -129,8 +129,12 @@ class BotMan
      */
     public function __construct(CacheInterface $cache, DriverInterface $driver, $config, StorageInterface $storage)
     {
+        if (!isset($config['bot_id'])) {
+            $config['bot_id'] = '';
+        }
+
         $this->cache = $cache;
-        $this->message = new IncomingMessage('', '', '');
+        $this->message = new IncomingMessage('', '', '', null, $config['bot_id']);
         $this->driver = $driver;
         $this->config = $config;
         $this->storage = $storage;
@@ -436,7 +440,7 @@ class BotMan
                 }
 
                 $this->firedDriverEvents = false;
-                $this->message = new IncomingMessage('', '', '');
+                $this->message = new IncomingMessage('', '', '', null, $this->config['bot_id']);
             }
         } catch (\Throwable $e) {
             $this->exceptionHandler->handleException($e, $this);
@@ -555,8 +559,12 @@ class BotMan
 
         $recipients = \is_array($recipients) ? $recipients : [$recipients];
 
+        if (!isset($this->config['bot_id'])) {
+            $this->config['bot_id'] = '';
+        }
+
         foreach ($recipients as $recipient) {
-            $this->message = new IncomingMessage('', $recipient, '');
+            $this->message = new IncomingMessage('', $recipient, '', null, $this->config['bot_id']);
             $response = $this->reply($message, $additionalParameters);
         }
 
@@ -580,7 +588,7 @@ class BotMan
             if (\is_string($driver)) {
                 $driver = DriverManager::loadFromName($driver, $this->config);
             }
-            $this->message = new IncomingMessage('', $recipient, '');
+            $this->message = new IncomingMessage('', $recipient, '', null, $this->config['bot_id']);
             $this->setDriver($driver);
         }
 

--- a/src/Messages/Incoming/IncomingMessage.php
+++ b/src/Messages/Incoming/IncomingMessage.php
@@ -17,6 +17,9 @@ class IncomingMessage
     /** @var string */
     protected $recipient;
 
+    /** @var string */
+    protected $bot_id;
+
     /** @var array */
     protected $images = [];
 
@@ -44,12 +47,13 @@ class IncomingMessage
     /** @var bool */
     protected $isFromBot = false;
 
-    public function __construct($message, $sender, $recipient, $payload = null)
+    public function __construct($message, $sender, $recipient, $payload = null, $bot_id = '')
     {
         $this->message = $message;
         $this->sender = $sender;
         $this->recipient = $recipient;
         $this->payload = $payload;
+        $this->bot_id = $bot_id;
     }
 
     /**
@@ -89,7 +93,7 @@ class IncomingMessage
      */
     public function getConversationIdentifier()
     {
-        return 'conversation-'.sha1($this->getSender()).'-'.sha1($this->getRecipient());
+        return 'conversation-'.$this->bot_id.sha1($this->getSender()).'-'.sha1($this->getRecipient());
     }
 
     /**
@@ -99,7 +103,7 @@ class IncomingMessage
      */
     public function getOriginatedConversationIdentifier()
     {
-        return 'conversation-'.sha1($this->getSender()).'-'.sha1('');
+        return 'conversation-'.$this->bot_id.sha1($this->getSender()).'-'.sha1('');
     }
 
     /**

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -21,7 +21,7 @@ trait HandlesConversations
     public function startConversation(Conversation $instance, $recipient = null, $driver = null)
     {
         if (! is_null($recipient) && ! is_null($driver)) {
-            $this->message = new IncomingMessage('', $recipient, '');
+            $this->message = new IncomingMessage('', $recipient, '', null, $this->config['bot_id']);
             $this->driver = DriverManager::loadFromName($driver, $this->config);
         }
         $instance->setBot($this);


### PR DESCRIPTION
Fixing issues: https://github.com/botman/botman/issues/1132, https://github.com/botman/botman/issues/1172

Optional bot_id config parameter added.
Using it while instantiating IncomingMessage object to insert in the cache key formed in getConversationIdentifier and getOriginatedConversationIdentifier.

New behavior:
Ability to have several bots sharing one project and same driver. If using multiple bots then bot_id config parameter needs to be defined for each bot.

Does this PR introduce a breaking change?
no