### PR TITLE
FIX PHP 8.4 deprecated implicitly nullable parameters

### DIFF
--- a/src/BotManFactory.php
+++ b/src/BotManFactory.php
@@ -50,9 +50,9 @@ class BotManFactory
      */
     public static function create(
         array $config,
-        CacheInterface $cache = null,
-        Request $request = null,
-        StorageInterface $storageDriver = null
+        ?CacheInterface $cache = null,
+        ?Request $request = null,
+        ?StorageInterface $storageDriver = null
     ) {
         if (empty($cache)) {
             $cache = new ArrayCache();
@@ -82,8 +82,8 @@ class BotManFactory
     public static function createForSocket(
         array $config,
         LoopInterface $loop,
-        CacheInterface $cache = null,
-        StorageInterface $storageDriver = null
+        ?CacheInterface $cache = null,
+        ?StorageInterface $storageDriver = null
     ) {
         $port = isset($config['port']) ? $config['port'] : 8080;
 
@@ -123,7 +123,7 @@ class BotManFactory
      * @param  Request|null $request
      * @return void
      */
-    public static function passRequestToSocket($port = 8080, Request $request = null)
+    public static function passRequestToSocket($port = 8080, ?Request $request = null)
     {
         if (empty($request)) {
             $request = Request::createFromGlobals();

--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -59,7 +59,7 @@ class DriverManager
      * @param Request|null $request
      * @return mixed|HttpDriver|NullDriver
      */
-    public static function loadFromName($name, array $config, Request $request = null)
+    public static function loadFromName($name, array $config, ?Request $request = null)
     {
         /*
         * Use the driver class basename without "Driver" if we're dealing with a
@@ -149,7 +149,7 @@ class DriverManager
      * @param Request|null $request
      * @return bool
      */
-    public static function verifyServices(array $config, Request $request = null)
+    public static function verifyServices(array $config, ?Request $request = null)
     {
         $request = (isset($request)) ? $request : Request::createFromGlobals();
         foreach (self::getAvailableHttpDrivers() as $driver) {

--- a/src/Middleware/MiddlewareManager.php
+++ b/src/Middleware/MiddlewareManager.php
@@ -109,7 +109,7 @@ class MiddlewareManager
      * @param Closure|null $destination
      * @return mixed
      */
-    public function applyMiddleware($method, $payload, array $additionalMiddleware = [], Closure $destination = null)
+    public function applyMiddleware($method, $payload, array $additionalMiddleware = [], ?Closure $destination = null)
     {
         $destination = is_null($destination) ? function ($payload) {
             return $payload;


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                                       
  PHP 8.4 deprecated implicitly nullable parameters (see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types). The following two method signatures in src/Drivers/DriverManager.php trigger deprecation warnings:                                                                                                                                                  
   
```
  PHP Deprecated: BotMan\BotMan\Drivers\DriverManager::loadFromName(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in .../vendor/botman/botman/src/Drivers/DriverManager.php on line 62                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                            
  PHP Deprecated: BotMan\BotMan\Drivers\DriverManager::verifyServices(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in .../vendor/botman/botman/src/Drivers/DriverManager.php on line 152
```  
